### PR TITLE
Keep Season opened but disable traffic

### DIFF
--- a/code/client/CMakeLists.txt
+++ b/code/client/CMakeLists.txt
@@ -33,7 +33,6 @@ set(MAFIAMP_CLIENT_FILES
     src/core/hooks/slot_wrapper.cpp
     src/core/hooks/stream_map.cpp
     src/core/hooks/tables.cpp
-    src/core/hooks/traffic.cpp
     src/core/hooks/translocator.cpp
     src/core/hooks/vehicle.cpp
     src/core/hooks/vfs.cpp

--- a/code/client/src/core/hooks/traffic.cpp
+++ b/code/client/src/core/hooks/traffic.cpp
@@ -1,8 +1,0 @@
-#include <utils/hooking/hooking.h>
-#include <utils/hooking/hook_function.h>
-
-static InitFunction init([]() {
-    //Disable traffic
-    const auto OpenSeasonAddr = hook::pattern("40 55 41 56 48 83 EC 48 83 B9 ? ? ? ? ?").get_first();
-    hook::return_function(OpenSeasonAddr);
-});

--- a/code/client/src/core/states/menu.cpp
+++ b/code/client/src/core/states/menu.cpp
@@ -31,6 +31,14 @@ namespace MafiaMP::Core::States {
         _shouldProceedConnection   = false;
         _shouldProceedOfflineDebug = false;
 
+        // Disable traffic and NPCs
+        gApplication->GetLuaVM()->ExecuteString("game.traffic:SetEnableAmbientTrafficSpawning(false)");
+        gApplication->GetLuaVM()->ExecuteString("game.traffic:SetMaxHumanElements(0)");
+        gApplication->GetLuaVM()->ExecuteString("game.traffic:SetTrainDensity(0)");
+
+        // Disable police
+        gApplication->GetLuaVM()->ExecuteString("game.police:Disable()");
+
         // Set camera
         Game::Helpers::Camera::SetPos({-986.40686, -304.061798, 2.292042}, {-985.365356, -336.348083, 2.892426}, true);
 


### PR DESCRIPTION
Related to https://github.com/MafiaHub/MafiaMP/issues/34 and temporary fix https://github.com/MafiaHub/MafiaMP/issues/25

This is just a working POC based on [Kamzik123 reply](https://github.com/MafiaHub/MafiaMP/issues/34#issuecomment-1885487492).

Next steps:
- Reverse `OpenSeason`, `CloseSeason` and `GetCurrentSeasonID` methods in order to expose them to scripting API
- Be sure, when the scripter change the `Season`, it will not reactivate traffic
- Do not use Lua but hooks


I can't do better with my limited knowledge of C++ and IDA.
I'll pass the topic on to you.

cc @zpl-zak @Greavesy1899 