### PR TITLE
Introduce Player Debug UI + fixes for debug stuffs

### DIFF
--- a/code/client/CMakeLists.txt
+++ b/code/client/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MAFIAMP_CLIENT_FILES
     src/core/ui/camera_studio.cpp
     src/core/ui/entity_browser.cpp
     src/core/ui/network_stats.cpp
+    src/core/ui/player_debug.cpp
     src/core/ui/vehicle_debug.cpp
     src/core/ui/web.cpp
     src/core/states/initialize.cpp

--- a/code/client/src/core/dev_features.cpp
+++ b/code/client/src/core/dev_features.cpp
@@ -44,6 +44,8 @@ namespace MafiaMP::Core {
     DevFeatures::DevFeatures() {
         _entityBrowser = std::make_shared<UI::EntityBrowser>();
         _cameraStudio  = std::make_shared<UI::CameraStudio>();
+        _playerDebug   = std::make_shared<UI::PlayerDebug>();
+        _vehicleDebug  = std::make_shared<UI::VehicleDebug>();
         _networkStats  = std::make_shared<UI::NetworkStats>();
     }
 

--- a/code/client/src/core/dev_features.cpp
+++ b/code/client/src/core/dev_features.cpp
@@ -55,24 +55,24 @@ namespace MafiaMP::Core {
     }
 
     void DevFeatures::Update() {
-        if (_showEntityBrowser) {
-            _entityBrowser->Update(&_showEntityBrowser);
+        if (_entityBrowser->IsVisible()) {
+            _entityBrowser->Update();
         }
 
-        if (_showCameraStudio) {
+        if (_cameraStudio->IsVisible()) {
             _cameraStudio->Update();
         }
 
-        if (_playerDebug->isVisible) {
+        if (_playerDebug->IsVisible()) {
             _playerDebug->Update();
         }
 
-        if (_showVehicleDebug) {
-            _vehicleDebug->Update(&_showVehicleDebug);
+        if (_vehicleDebug->IsVisible()) {
+            _vehicleDebug->Update();
         }
 
-        if (_showNetworkStats) {
-            _networkStats->Update(&_showNetworkStats);
+        if (_networkStats->IsVisible()) {
+            _networkStats->Update();
         }
 
         if (gApplication->_input->IsKeyPressed(FW_KEY_F1)) {
@@ -166,9 +166,9 @@ namespace MafiaMP::Core {
         }
 
         if (gApplication->_input->IsKeyPressed(FW_KEY_F7)) {
-            gApplication->GetImGUI()->ShowCursor(!_showCameraStudio);
-            MafiaMP::Game::Helpers::Controls::Lock(!_showCameraStudio);
-            _showCameraStudio = !_showCameraStudio;
+            gApplication->GetImGUI()->ShowCursor(!_cameraStudio->IsVisible());
+            MafiaMP::Game::Helpers::Controls::Lock(!_cameraStudio->IsVisible());
+            ToggleCameraStudio();
         }
 
         if (gApplication->_input->IsKeyPressed(FW_KEY_F10)) {
@@ -208,23 +208,23 @@ namespace MafiaMP::Core {
     }
 
     void DevFeatures::ToggleEntityBrowser() {
-        _showEntityBrowser = !_showEntityBrowser;
+        _entityBrowser->SetVisible(!_entityBrowser->IsVisible());
     }
 
     void DevFeatures::ToggleCameraStudio() {
-        _showCameraStudio = !_showCameraStudio;
+        _cameraStudio->SetVisible(!_playerDebug->IsVisible());
     }
 
     void DevFeatures::TogglePlayerDebug() {
-        _playerDebug->isVisible = !_playerDebug->isVisible;
+        _playerDebug->SetVisible(!_playerDebug->IsVisible());
     }
 
     void DevFeatures::ToggleVehicleDebug() {
-        _showVehicleDebug = !_showVehicleDebug;
+        _vehicleDebug->SetVisible(!_vehicleDebug->IsVisible());
     }
 
     void DevFeatures::ToggleNetworkStats() {
-        _showNetworkStats = !_showNetworkStats;
+        _networkStats->SetVisible(!_networkStats->IsVisible());
     }
 
     void DevFeatures::SpawnCrashObject() {

--- a/code/client/src/core/dev_features.cpp
+++ b/code/client/src/core/dev_features.cpp
@@ -63,8 +63,8 @@ namespace MafiaMP::Core {
             _cameraStudio->Update();
         }
 
-        if (_showPlayerDebug) {
-            _playerDebug->Update(&_showPlayerDebug);
+        if (_playerDebug->isVisible) {
+            _playerDebug->Update();
         }
 
         if (_showVehicleDebug) {
@@ -216,7 +216,7 @@ namespace MafiaMP::Core {
     }
 
     void DevFeatures::TogglePlayerDebug() {
-        _showPlayerDebug = !_showPlayerDebug;
+        _playerDebug->isVisible = !_playerDebug->isVisible;
     }
 
     void DevFeatures::ToggleVehicleDebug() {

--- a/code/client/src/core/dev_features.cpp
+++ b/code/client/src/core/dev_features.cpp
@@ -73,8 +73,6 @@ namespace MafiaMP::Core {
             _networkStats->Update(&_showNetworkStats);
         }
 
-        /*--------------------------------------------------------------------------*/
-
         if (gApplication->_input->IsKeyPressed(FW_KEY_F1)) {
             const auto human = Game::Helpers::Controls::GetLocalPlayer();
             if (human) {

--- a/code/client/src/core/dev_features.h
+++ b/code/client/src/core/dev_features.h
@@ -16,8 +16,9 @@
 
 #include "ui/camera_studio.h"
 #include "ui/entity_browser.h"
-#include "ui/vehicle_debug.h"
 #include "ui/network_stats.h"
+#include "ui/player_debug.h"
+#include "ui/vehicle_debug.h"
 
 #include "sdk/entities/c_human_2.h"
 
@@ -33,7 +34,10 @@ namespace MafiaMP::Core {
         bool _showCameraStudio {false};
         std::shared_ptr<UI::CameraStudio> _cameraStudio {};
 
-        bool _showVehicledebug {false};
+        bool _showPlayerDebug {false};
+        std::shared_ptr<UI::PlayerDebug> _playerDebug {};
+
+        bool _showVehicleDebug {false};
         std::shared_ptr<UI::VehicleDebug> _vehicleDebug {};
 
         bool _showNetworkStats {false};
@@ -59,6 +63,7 @@ namespace MafiaMP::Core {
 
         void ToggleEntityBrowser();
         void ToggleCameraStudio();
+        void TogglePlayerDebug();
         void ToggleVehicleDebug();
         void ToggleNetworkStats();
     };

--- a/code/client/src/core/dev_features.h
+++ b/code/client/src/core/dev_features.h
@@ -28,18 +28,14 @@ namespace MafiaMP::Core {
         std::vector<Game::Streaming::EntityTrackingInfo *> _TEMP_vehicles;
         Game::Streaming::EntityTrackingInfo *_TEMP_HUMAN = nullptr;
 
-        bool _showEntityBrowser {false};
         std::shared_ptr<UI::EntityBrowser> _entityBrowser {};
 
-        bool _showCameraStudio {false};
         std::shared_ptr<UI::CameraStudio> _cameraStudio {};
 
         std::shared_ptr<UI::PlayerDebug> _playerDebug {};
 
-        bool _showVehicleDebug {false};
         std::shared_ptr<UI::VehicleDebug> _vehicleDebug {};
 
-        bool _showNetworkStats {false};
         std::shared_ptr<UI::NetworkStats> _networkStats {};
 
       public:

--- a/code/client/src/core/dev_features.h
+++ b/code/client/src/core/dev_features.h
@@ -34,7 +34,6 @@ namespace MafiaMP::Core {
         bool _showCameraStudio {false};
         std::shared_ptr<UI::CameraStudio> _cameraStudio {};
 
-        bool _showPlayerDebug {false};
         std::shared_ptr<UI::PlayerDebug> _playerDebug {};
 
         bool _showVehicleDebug {false};

--- a/code/client/src/core/hooks/human.cpp
+++ b/code/client/src/core/hooks/human.cpp
@@ -1,25 +1,25 @@
 #include <utils/safe_win32.h>
+
 #include <MinHook.h>
 #include <utils/hooking/hook_function.h>
 #include <utils/hooking/hooking.h>
 
+#include "sdk/c_player_teleport_module.h"
 #include "sdk/entities/c_actor.h"
 #include "sdk/entities/c_car.h"
-#include "sdk/ue/game/humainai/c_character_controller.h"
 #include "sdk/entities/c_player_2.h"
-#include "sdk/entities/c_human_2.h"
-#include "sdk/entities//human/c_human_script.h"
-#include "sdk/c_player_teleport_module.h"
+#include "sdk/ue/game/humainai/c_character_controller.h"
+
 #include "game/helpers/controls.h"
 
 #include "core/application.h"
-#include "world/client.h"
 #include "shared/game_rpc/human/human_death.h"
+#include "world/client.h"
 
-#include <logging/logger.h>
 #include "sdk/mafia/ui/c_game_gui_2_module.h"
+#include <logging/logger.h>
 
-typedef void(__fastcall *C_Human2__SetupDeath_t)(SDK::C_Human2 *_this, void*);
+typedef void(__fastcall *C_Human2__SetupDeath_t)(SDK::C_Human2 *_this, void *);
 C_Human2__SetupDeath_t C_Human2__SetupDeath_original = nullptr;
 void __fastcall C_Human2__SetupDeath(SDK::C_Human2 *pThis, void *entityMsgDamage) {
     // Is the local player ?

--- a/code/client/src/core/modules/human.cpp
+++ b/code/client/src/core/modules/human.cpp
@@ -4,24 +4,21 @@
 
 #include <flecs/flecs.h>
 
-#include "sdk/c_game.h"
-#include "sdk/entities/c_car.h"
-#include "sdk/entities/c_player_2.h"
-#include "sdk/entities/c_vehicle.h"
-#include "sdk/entities/human/c_human_script.h"
-#include "sdk/entities/human/c_human_weapon_controller.h"
-#include "sdk/wrappers/c_human_2_car_wrapper.h"
-#include "sdk/c_player_teleport_module.h"
-
 #include "game/helpers/controls.h"
 #include "game/helpers/human.h"
 #include "game/overrides/character_controller.h"
 #include "game/streaming/entity_tracking_info.h"
+#include "sdk/c_game.h"
+#include "sdk/c_player_teleport_module.h"
+#include "sdk/entities/c_car.h"
+#include "sdk/entities/c_player_2.h"
+#include "sdk/entities/c_vehicle.h"
+#include "sdk/wrappers/c_human_2_car_wrapper.h"
 
-#include "shared/game_rpc/human/human_shoot.h"
-#include "shared/game_rpc/human/human_reload.h"
 #include "shared/game_rpc/human/human_changeskin.h"
+#include "shared/game_rpc/human/human_reload.h"
 #include "shared/game_rpc/human/human_setprops.h"
+#include "shared/game_rpc/human/human_shoot.h"
 
 #include "vehicle.h"
 #include <world/modules/base.hpp>
@@ -164,11 +161,6 @@ namespace MafiaMP::Core::Modules {
                 trackingData->charController = reinterpret_cast<MafiaMP::Game::Overrides::CharacterController *>(human->GetCharacterController());
                 assert(MafiaMP::Game::Overrides::CharacterController::IsInstanceOfClass(trackingData->charController));
 
-                // TODO(DavoSK): remove
-                Game::Helpers::Human::AddWeapon(human, 85, 200);
-                Game::Helpers::Human::AddWeapon(human, 3, 200);
-                Game::Helpers::Human::AddWeapon(human, 13, 200);
-                
                 Update(ent);
             }
         };
@@ -204,10 +196,6 @@ namespace MafiaMP::Core::Modules {
         e.add<HumanData>();
         e.set<Shared::Modules::Mod::EntityKind>({Shared::Modules::Mod::MOD_PLAYER});
 
-        // TODO(DavoSK): remove
-        Game::Helpers::Human::AddWeapon(trackingData->human, 85, 200);
-        Game::Helpers::Human::AddWeapon(trackingData->human, 3, 200);
-
         const auto es            = e.get_mut<Framework::World::Modules::Base::Streamable>();
         es->modEvents.updateProc = [](Framework::Networking::NetworkPeer *peer, uint64_t guid, flecs::entity e) {
             const auto updateData = e.get<Shared::Modules::HumanSync::UpdateData>();
@@ -226,6 +214,7 @@ namespace MafiaMP::Core::Modules {
             return;
         }
 
+        // TODO: Explain why do we have to do this
         trackingData->human->GetHumanScript()->SetDemigod(true);
         trackingData->human->GetHumanScript()->SetInvulnerabilityByScript(true);
 
@@ -258,7 +247,7 @@ namespace MafiaMP::Core::Modules {
         // Update basic data
         const auto tr = e.get<Framework::World::Modules::Base::Transform>();
         if (e.get<Interpolated>()) {
-            auto interp   = e.get_mut<Interpolated>();
+            auto interp         = e.get_mut<Interpolated>();
             const auto humanPos = trackingData->human->GetPos();
             const auto humanRot = trackingData->human->GetRot();
             interp->interpolator.GetPosition()->SetTargetValue({humanPos.x, humanPos.y, humanPos.z}, tr->pos, MafiaMP::Core::gApplication->GetTickInterval());
@@ -432,7 +421,8 @@ namespace MafiaMP::Core::Modules {
 
             if (e == gApplication->GetLocalPlayer()) {
                 Game::Helpers::Controls::PlayerChangeSpawnProfile(msg->GetSpawnProfile());
-            } else {
+            }
+            else {
                 // todo remote ped
             }
         });
@@ -468,7 +458,7 @@ namespace MafiaMP::Core::Modules {
         // Update basic data
         const auto tr = e.get<Framework::World::Modules::Base::Transform>();
         if (e.get<Interpolated>()) {
-            auto interp   = e.get_mut<Interpolated>();
+            auto interp = e.get_mut<Interpolated>();
             // todo reset lerp
             const auto humanPos = trackingData->human->GetPos();
             const auto humanRot = trackingData->human->GetRot();
@@ -483,7 +473,8 @@ namespace MafiaMP::Core::Modules {
             transform.SetRot(newRot);
             transform.SetPos(newPos);
             trackingData->human->SetTransform(transform);
-        } else {
+        }
+        else {
             SDK::ue::sys::math::C_Vector newPos    = {tr->pos.x, tr->pos.y, tr->pos.z};
             SDK::ue::sys::math::C_Quat newRot      = {tr->rot.x, tr->rot.y, tr->rot.z, tr->rot.w};
             SDK::ue::sys::math::C_Matrix transform = {};
@@ -497,7 +488,7 @@ namespace MafiaMP::Core::Modules {
         }
     }
 
-    flecs::entity Human::GetHumanEntity(SDK::C_Human2* ptr) {
+    flecs::entity Human::GetHumanEntity(SDK::C_Human2 *ptr) {
         flecs::entity foundPlayerEntity {};
         findAllHumans.each([ptr, &foundPlayerEntity](flecs::entity e, Human::Tracking &tracking) {
             if (tracking.human == ptr) {

--- a/code/client/src/core/modules/human.cpp
+++ b/code/client/src/core/modules/human.cpp
@@ -214,7 +214,11 @@ namespace MafiaMP::Core::Modules {
             return;
         }
 
-        // TODO: Explain why do we have to do this
+        /**
+         * Ensure remote human doesn't die on client-side due to client-only factors.
+         * This way we reflect actual health the player has and don't run into desync issue
+         * where player would die on someone else's screen even if they shouldn't.
+         */
         trackingData->human->GetHumanScript()->SetDemigod(true);
         trackingData->human->GetHumanScript()->SetInvulnerabilityByScript(true);
 

--- a/code/client/src/core/ui/camera_studio.cpp
+++ b/code/client/src/core/ui/camera_studio.cpp
@@ -32,8 +32,10 @@ static InitFunction init([]() {
 });
 
 namespace MafiaMP::Core::UI {
+    CameraStudio::CameraStudio() {}
+
     void CameraStudio::Update() {
-        ImGui::Begin("Camera studio");
+        ImGui::Begin("Camera studio", &_visible);
         {
             if (ImGui::Button("Enable")) {
                 auto addr1            = hook::get_opcode_address("E8 ? ? ? ? 33 F6 EB 9F");

--- a/code/client/src/core/ui/camera_studio.h
+++ b/code/client/src/core/ui/camera_studio.h
@@ -7,14 +7,28 @@
 
 namespace MafiaMP::Core::UI {
     class CameraStudio final {
-      private:
-        bool _isEnabled                            = false;
-        SDK::ue::sys::core::C_SceneObject *_camera = nullptr;
-        SDK::ue::sys::math::C_Vector _camForward   = {1.0f, 0.0f, 0.0f};
-        POINT _mouseDelta {};
-        POINT _lastMousePos {};
-
       public:
+        CameraStudio();
+
         void Update();
+
+        bool IsVisible() const {
+            return _visible;
+        }
+
+        void SetVisible(bool visible) {
+            _visible = visible;
+        }
+
+      private:
+        bool _visible = false;
+
+        SDK::ue::sys::core::C_SceneObject *_camera = nullptr;
+
+        SDK::ue::sys::math::C_Vector _camForward = {1.0f, 0.0f, 0.0f};
+
+        POINT _mouseDelta {};
+
+        POINT _lastMousePos {};
     };
 } // namespace MafiaMP::Core::UI

--- a/code/client/src/core/ui/entity_browser.cpp
+++ b/code/client/src/core/ui/entity_browser.cpp
@@ -4,13 +4,13 @@
 #include <external/imgui/wrapper.h>
 #include <imgui.h>
 
-#include <sdk/entities/c_entity_list.h>
-#include <sdk/entities/c_player_2.h>
-#include <sdk/entities/c_human_2.h>
 #include <sdk/entities/c_car.h>
+#include <sdk/entities/c_entity_list.h>
+#include <sdk/entities/c_human_2.h>
+#include <sdk/entities/c_player_2.h>
 
-#include "core/modules/vehicle.h"
 #include "core/modules/human.h"
+#include "core/modules/vehicle.h"
 #include "game/helpers/controls.h"
 
 namespace MafiaMP::Core::UI {
@@ -18,7 +18,7 @@ namespace MafiaMP::Core::UI {
         InitialiseEntityTypes();
     }
 
-    void EntityBrowser::Update() {
+    void EntityBrowser::Update(bool *isVisible) {
         auto entityList = SDK::GetEntityList();
         if (!entityList)
             return;
@@ -27,7 +27,7 @@ namespace MafiaMP::Core::UI {
         if (!localPlayer)
             return;
 
-        ImGui::Begin("Entity Browser");
+        ImGui::Begin("Entity Browser", isVisible);
         {
             if (ImGui::Button("Select all")) {
                 for (size_t i = 0; i < (sizeof(_checkedTypes) / sizeof(_checkedTypes[0])); i++) _checkedTypes[i] = true;
@@ -67,8 +67,7 @@ namespace MafiaMP::Core::UI {
             static const char *streamFilterNames[]  = {"None", "Streamed", "Owned"};
             static const char *selectedStreamFilter = streamFilterNames[0];
 
-            if (ImGui::BeginCombo("Streamable filter", selectedStreamFilter))
-            {
+            if (ImGui::BeginCombo("Streamable filter", selectedStreamFilter)) {
                 for (int n = 0; n < IM_ARRAYSIZE(streamFilterNames); n++) {
                     bool is_selected = (selectedStreamFilter == streamFilterNames[n]);
                     if (ImGui::Selectable(streamFilterNames[n], is_selected)) {
@@ -125,8 +124,8 @@ namespace MafiaMP::Core::UI {
                         // TODO: better way to detect streamables
 
                         if (sceneObjectType == SDK::E_EntityType::E_ENTITY_CAR) {
-                            const auto veh = reinterpret_cast<SDK::C_Car* >(entity);
-                            
+                            const auto veh = reinterpret_cast<SDK::C_Car *>(entity);
+
                             e = Core::Modules::Vehicle::GetCarEntity(veh);
                         }
                         else if (sceneObjectType == SDK::E_EntityType::E_ENTITY_HUMAN /*|| sceneObjectType == SDK::E_EntityType::E_ENTITY_PLAYER*/) {
@@ -162,11 +161,13 @@ namespace MafiaMP::Core::UI {
                         auto entityPos = inspectedEntity->GetPos();
                         auto entityDir = inspectedEntity->GetDir();
 
-                        if (ImGui::DragFloat3("Pos", (float *)&entityPos, 0.1f, -2000.0f, 2000.0, "%.3f", 1.0f))
+                        if (ImGui::DragFloat3("Pos", (float *)&entityPos, 0.1f, -2000.0f, 2000.0f)) {
                             inspectedEntity->SetPos(entityPos);
+                        }
 
-                        if (ImGui::DragFloat3("Dir", (float *)&entityDir, 0.1f, -2000.0f, 2000.0, "%.3f", 1.0f))
+                        if (ImGui::DragFloat3("Dir", (float *)&entityDir, 0.01f, -1.0f, 1.0f)) {
                             inspectedEntity->SetDir(entityDir);
+                        }
 
                         if (ImGui::Button("Teleport to entity")) {
                             (reinterpret_cast<SDK::C_Actor *>(localPlayer))->SetPos(entityPos);

--- a/code/client/src/core/ui/entity_browser.cpp
+++ b/code/client/src/core/ui/entity_browser.cpp
@@ -18,7 +18,7 @@ namespace MafiaMP::Core::UI {
         InitialiseEntityTypes();
     }
 
-    void EntityBrowser::Update(bool *isVisible) {
+    void EntityBrowser::Update() {
         auto entityList = SDK::GetEntityList();
         if (!entityList)
             return;
@@ -27,7 +27,7 @@ namespace MafiaMP::Core::UI {
         if (!localPlayer)
             return;
 
-        ImGui::Begin("Entity Browser", isVisible);
+        ImGui::Begin("Entity Browser", &_visible);
         {
             if (ImGui::Button("Select all")) {
                 for (size_t i = 0; i < (sizeof(_checkedTypes) / sizeof(_checkedTypes[0])); i++) _checkedTypes[i] = true;

--- a/code/client/src/core/ui/entity_browser.h
+++ b/code/client/src/core/ui/entity_browser.h
@@ -15,9 +15,19 @@ namespace MafiaMP::Core::UI {
       public:
         EntityBrowser();
 
-        void Update(bool *isVisible);
+        void Update();
+
+        bool IsVisible() const {
+            return _visible;
+        }
+
+        void SetVisible(bool visible) {
+            _visible = visible;
+        }
 
       private:
+        bool _visible = false;
+
         int _selectedIndex = 0;
         std::unordered_map<SDK::E_EntityType, std::string> _allTypes {};
 

--- a/code/client/src/core/ui/entity_browser.h
+++ b/code/client/src/core/ui/entity_browser.h
@@ -15,7 +15,7 @@ namespace MafiaMP::Core::UI {
       public:
         EntityBrowser();
 
-        void Update();
+        void Update(bool *isVisible);
 
       private:
         int _selectedIndex = 0;

--- a/code/client/src/core/ui/network_stats.cpp
+++ b/code/client/src/core/ui/network_stats.cpp
@@ -13,13 +13,12 @@ namespace MafiaMP::Core::UI {
 
     NetworkStats::NetworkStats() {}
 
-    void NetworkStats::Update() {
+    void NetworkStats::Update(bool *isVisible) {
         auto localPlayer = Game::Helpers::Controls::GetLocalPlayer();
         if (!localPlayer)
             return;
 
-        static bool alwaysTrue = true;
-        ImGui::Begin("Network Stats", &alwaysTrue, ImGuiWindowFlags_AlwaysAutoResize);
+        ImGui::Begin("Network Stats", isVisible, ImGuiWindowFlags_AlwaysAutoResize);
         {
             const auto net   = gApplication->GetNetworkingEngine()->GetNetworkClient();
             const auto state = net->GetConnectionState();
@@ -33,8 +32,8 @@ namespace MafiaMP::Core::UI {
             if (_nextStatsUpdate < Framework::Utils::Time::GetTime()) {
                 _nextStatsUpdate = Framework::Utils::Time::GetTime() + 500;
 
-                const auto peer   = net->GetPeer();
-                const auto stats  = peer->GetStatistics(peer->GetSystemAddressFromIndex(0), nullptr);
+                const auto peer  = net->GetPeer();
+                const auto stats = peer->GetStatistics(peer->GetSystemAddressFromIndex(0), nullptr);
                 ::memset(_stats, 0, sizeof(_stats));
                 SLNet::StatisticsToString(stats, _stats, 2);
             }

--- a/code/client/src/core/ui/network_stats.cpp
+++ b/code/client/src/core/ui/network_stats.cpp
@@ -10,15 +10,14 @@
 #include "game/helpers/controls.h"
 
 namespace MafiaMP::Core::UI {
-
     NetworkStats::NetworkStats() {}
 
-    void NetworkStats::Update(bool *isVisible) {
+    void NetworkStats::Update() {
         auto localPlayer = Game::Helpers::Controls::GetLocalPlayer();
         if (!localPlayer)
             return;
 
-        ImGui::Begin("Network Stats", isVisible, ImGuiWindowFlags_AlwaysAutoResize);
+        ImGui::Begin("Network Stats", &_visible, ImGuiWindowFlags_AlwaysAutoResize);
         {
             const auto net   = gApplication->GetNetworkingEngine()->GetNetworkClient();
             const auto state = net->GetConnectionState();

--- a/code/client/src/core/ui/network_stats.h
+++ b/code/client/src/core/ui/network_stats.h
@@ -8,9 +8,9 @@ namespace MafiaMP::Core::UI {
       public:
         NetworkStats();
 
-        void Update();
+        void Update(bool *isVisible);
 
-    private:
+      private:
         int64_t _nextStatsUpdate = 0;
         char _stats[8192]        = {0};
     };

--- a/code/client/src/core/ui/network_stats.h
+++ b/code/client/src/core/ui/network_stats.h
@@ -8,10 +8,21 @@ namespace MafiaMP::Core::UI {
       public:
         NetworkStats();
 
-        void Update(bool *isVisible);
+        void Update();
+
+        bool IsVisible() const {
+            return _visible;
+        }
+
+        void SetVisible(bool visible) {
+            _visible = visible;
+        }
 
       private:
+        bool _visible = false;
+
         int64_t _nextStatsUpdate = 0;
-        char _stats[8192]        = {0};
+
+        char _stats[8192] = {0};
     };
 } // namespace MafiaMP::Core::UI

--- a/code/client/src/core/ui/player_debug.cpp
+++ b/code/client/src/core/ui/player_debug.cpp
@@ -124,8 +124,8 @@ namespace MafiaMP::Core::UI {
 
         if (ImGui::Button("Teleport to Salieri's Bar")) {
             SDK::ue::C_CntPtr<uintptr_t> syncObject;
-            auto pos = SDK::ue::sys::math::C_Vector(-908.717, 209.283, 2.793);
-            auto dir = SDK::ue::sys::math::C_Vector(0.985, -0.175, 0.000);
+            auto pos = SDK::ue::sys::math::C_Vector(-916.0, -210.0, 2.605);
+            auto dir = SDK::ue::sys::math::C_Vector(1.0, 0.0, 0.0);
             SDK::GetPlayerTeleportModule()->TeleportPlayer(syncObject, pos, dir, false, false, false, false);
         }
 

--- a/code/client/src/core/ui/player_debug.cpp
+++ b/code/client/src/core/ui/player_debug.cpp
@@ -10,7 +10,7 @@
 namespace MafiaMP::Core::UI {
     PlayerDebug::PlayerDebug() {}
 
-    void PlayerDebug::Update(bool *isVisible) {
+    void PlayerDebug::Update() {
         /**
          * TODO
          * - Implement GetScale/SetScale => see https://github.com/MafiaHub/MafiaMP/issues/49
@@ -21,7 +21,7 @@ namespace MafiaMP::Core::UI {
         if (!pActivePlayer)
             return;
 
-        ImGui::Begin("Player debug", isVisible);
+        ImGui::Begin("Player debug", &isVisible);
 
         auto position = pActivePlayer->GetPos();
         if (ImGui::DragFloat3("Pos", (float *)&position, 0.1f, -2000.0f, 2000.0f)) {

--- a/code/client/src/core/ui/player_debug.cpp
+++ b/code/client/src/core/ui/player_debug.cpp
@@ -97,13 +97,7 @@ namespace MafiaMP::Core::UI {
             (health);
         }
 
-        /**
-         * SetHealthMax is explicitly disabled for the player
-         */
-        // float healthMax = pActivePlayer->GetHumanScript()->GetHealthMax();
-        // if (ImGui::SliderFloat("Health Max", &healthMax, 0.0f, 1000.0f)) {
-        //     pActivePlayer->GetHumanScript()->SetHealthMax(healthMax);
-        // }
+        // SetHealthMax is explicitly disabled for the player
         ImGui::Text("Health Max: %f\n", pActivePlayer->GetHumanScript()->GetHealthMax());
 
         {
@@ -148,15 +142,6 @@ namespace MafiaMP::Core::UI {
             auto dir = SDK::ue::sys::math::C_Vector(0.985, -0.175, 0.000);
             SDK::GetPlayerTeleportModule()->TeleportPlayer(syncObject, pos, dir, false, false, false, false);
         }
-
-        // void pActivePlayer->GetHumanScript()->GetOnVehicle(ue::C_CntPtr<uintptr_t> &outSyncObject, C_Actor *arg1, unsigned int arg2, bool arg3, bool arg4, E_HumanMoveMode moveMode, bool force) {
-        //     (*(void(__thiscall *)(C_HumanScript *, ue::C_CntPtr<uintptr_t> &, C_Actor *, unsigned int, bool, bool, E_HumanMoveMode, bool))gPatterns.C_HumanScript__GetOnVehicle)(
-        //         this, outSyncObject, arg1, arg2, arg3, arg4, moveMode, force);
-        // }
-
-        // void pActivePlayer->GetHumanScript()->GetOffVehicle(ue::C_CntPtr<uintptr_t> &outSyncObject, C_Actor *arg1, bool arg2, bool arg3) {
-        //     (*(void(__thiscall *)(C_HumanScript *, ue::C_CntPtr<uintptr_t> &, C_Actor *, bool, bool))gPatterns.C_HumanScript__GetOffVehicle)(this, outSyncObject, arg1, arg2, arg3);
-        // }
 
         ImGui::Text("Player Ptr: %p", pActivePlayer);
 

--- a/code/client/src/core/ui/player_debug.cpp
+++ b/code/client/src/core/ui/player_debug.cpp
@@ -21,7 +21,7 @@ namespace MafiaMP::Core::UI {
         if (!pActivePlayer)
             return;
 
-        ImGui::Begin("Player debug", &isVisible);
+        ImGui::Begin("Player debug", &_visible);
 
         auto position = pActivePlayer->GetPos();
         if (ImGui::DragFloat3("Pos", (float *)&position, 0.1f, -2000.0f, 2000.0f)) {

--- a/code/client/src/core/ui/player_debug.cpp
+++ b/code/client/src/core/ui/player_debug.cpp
@@ -11,6 +11,12 @@ namespace MafiaMP::Core::UI {
     PlayerDebug::PlayerDebug() {}
 
     void PlayerDebug::Update(bool *isVisible) {
+        /**
+         * TODO
+         * - Implement GetScale/SetScale => see https://github.com/MafiaHub/MafiaMP/issues/49
+         * - Implement kill player => see https://github.com/MafiaHub/MafiaMP/issues/52
+         */
+
         const auto pActivePlayer = Game::Helpers::Controls::GetLocalPlayer();
         if (!pActivePlayer)
             return;
@@ -31,19 +37,6 @@ namespace MafiaMP::Core::UI {
         if (ImGui::DragFloat4("Rot", (float *)&rot, 0.01f, -1.0f, 1.0f)) {
             pActivePlayer->SetRot(rot);
         }
-
-        /**
-         * TODO: Scale is float or Vector3 ?
-         */
-        // auto scale = pActivePlayer->GetScale();
-        // if (ImGui::SliderFloat4("Scale", (float *)&scale, 0.0f, 1.0f)) {
-        //     // pActivePlayer->SetScale(scale);
-        // }
-
-        // float scale = pActivePlayer->GetScale();
-        // if (ImGui::SliderFloat("Scale", &scale, 0.0f, 1.0f)) {
-        //     pActivePlayer->SetScale(scale);
-        // }
 
         float transparency = pActivePlayer->GetTransparency();
         if (ImGui::SliderFloat("Transparency", &transparency, 0.0f, 1.0f)) {
@@ -112,13 +105,6 @@ namespace MafiaMP::Core::UI {
                 pActivePlayer->GetHumanScript()->SetHealth(-1.0f); // Doesn't kill the player
             }
         }
-
-        /**
-         * TODO: How to kill the player?
-         */
-        // if (ImGui::Button("Kill")) {
-        //     // ??
-        // }
 
         {
             if (ImGui::Button("Give weapons")) {

--- a/code/client/src/core/ui/player_debug.h
+++ b/code/client/src/core/ui/player_debug.h
@@ -2,14 +2,6 @@
 
 #include "utils/safe_win32.h"
 
-#include <fu2/function2.hpp>
-
-#include <string>
-#include <unordered_map>
-#include <vector>
-
-#include "sdk/entities/c_entity.h"
-
 namespace MafiaMP::Core::UI {
     class PlayerDebug final {
       public:

--- a/code/client/src/core/ui/player_debug.h
+++ b/code/client/src/core/ui/player_debug.h
@@ -11,9 +11,9 @@
 #include "sdk/entities/c_entity.h"
 
 namespace MafiaMP::Core::UI {
-    class VehicleDebug final {
+    class PlayerDebug final {
       public:
-        VehicleDebug();
+        PlayerDebug();
 
         void Update(bool *isVisible);
     };

--- a/code/client/src/core/ui/player_debug.h
+++ b/code/client/src/core/ui/player_debug.h
@@ -15,8 +15,17 @@ namespace MafiaMP::Core::UI {
       public:
         PlayerDebug();
 
-        bool isVisible = false;
-
         void Update();
+
+        bool IsVisible() const {
+            return _visible;
+        }
+
+        void SetVisible(bool visible) {
+            _visible = visible;
+        }
+
+      private:
+        bool _visible = false;
     };
 } // namespace MafiaMP::Core::UI

--- a/code/client/src/core/ui/player_debug.h
+++ b/code/client/src/core/ui/player_debug.h
@@ -15,6 +15,8 @@ namespace MafiaMP::Core::UI {
       public:
         PlayerDebug();
 
-        void Update(bool *isVisible);
+        bool isVisible = false;
+
+        void Update();
     };
 } // namespace MafiaMP::Core::UI

--- a/code/client/src/core/ui/vehicle_debug.cpp
+++ b/code/client/src/core/ui/vehicle_debug.cpp
@@ -13,11 +13,11 @@
 namespace MafiaMP::Core::UI {
     VehicleDebug::VehicleDebug() {}
 
-    void VehicleDebug::Update(bool *isVisible) {
+    void VehicleDebug::Update() {
         const auto pActivePlayer = Game::Helpers::Controls::GetLocalPlayer();
         SDK::C_Car *currentCar   = pActivePlayer ? reinterpret_cast<SDK::C_Car *>(pActivePlayer->GetOwner()) : nullptr;
 
-        ImGui::Begin("Vehicle debug", isVisible, ImGuiWindowFlags_AlwaysAutoResize);
+        ImGui::Begin("Vehicle debug", &_visible, ImGuiWindowFlags_AlwaysAutoResize);
 
         if (currentCar) {
             auto currentVehicle = currentCar->GetVehicle();

--- a/code/client/src/core/ui/vehicle_debug.cpp
+++ b/code/client/src/core/ui/vehicle_debug.cpp
@@ -11,22 +11,29 @@
 #include "game/helpers/controls.h"
 
 namespace MafiaMP::Core::UI {
-    VehicleDebug::VehicleDebug() {
-    }
+    VehicleDebug::VehicleDebug() {}
 
-    void VehicleDebug::Update() {
+    void VehicleDebug::Update(bool *isVisible) {
         const auto pActivePlayer = Game::Helpers::Controls::GetLocalPlayer();
-        SDK::C_Car *currentCar = pActivePlayer ? reinterpret_cast<SDK::C_Car *>(pActivePlayer->GetOwner()) : nullptr;
+        SDK::C_Car *currentCar   = pActivePlayer ? reinterpret_cast<SDK::C_Car *>(pActivePlayer->GetOwner()) : nullptr;
+
+        ImGui::Begin("Vehicle debug", isVisible, ImGuiWindowFlags_AlwaysAutoResize);
+
         if (currentCar) {
             auto currentVehicle = currentCar->GetVehicle();
 
             auto position = currentCar->GetPos();
-            if (ImGui::SliderFloat3("Pos", (float *)&position, -50000.0, 50000.0)) {
+            if (ImGui::DragFloat3("Pos", (float *)&position, 0.1f, -2000.0f, 2000.0f)) {
                 currentCar->SetPos(position);
             }
 
+            auto dir = currentCar->GetDir();
+            if (ImGui::DragFloat3("Dir", (float *)&dir, 0.01f, -1.0f, 1.0f)) {
+                currentCar->SetDir(dir);
+            }
+
             auto rot = currentCar->GetRot();
-            if (ImGui::SliderFloat4("Rot", (float *)&rot, -1.0, 1.0)) {
+            if (ImGui::DragFloat4("Rot", (float *)&rot, 0.01f, -1.0f, 1.0f)) {
                 currentCar->SetRot(rot);
             }
 
@@ -146,5 +153,10 @@ namespace MafiaMP::Core::UI {
                 currentVehicle->ChangeRadioStation(currentStation == 1 ? 0 : 1);
             }
         }
+        else {
+            ImGui::Text("You're not in a vehicle!");
+        }
+
+        ImGui::End();
     }
 }; // namespace MafiaMP::Core::UI

--- a/code/client/src/core/ui/vehicle_debug.h
+++ b/code/client/src/core/ui/vehicle_debug.h
@@ -15,6 +15,17 @@ namespace MafiaMP::Core::UI {
       public:
         VehicleDebug();
 
-        void Update(bool *isVisible);
+        void Update();
+
+        bool IsVisible() const {
+            return _visible;
+        }
+
+        void SetVisible(bool visible) {
+            _visible = visible;
+        }
+
+      private:
+        bool _visible = false;
     };
 } // namespace MafiaMP::Core::UI

--- a/code/client/src/core/ui/vehicle_debug.h
+++ b/code/client/src/core/ui/vehicle_debug.h
@@ -2,14 +2,6 @@
 
 #include "utils/safe_win32.h"
 
-#include <fu2/function2.hpp>
-
-#include <string>
-#include <unordered_map>
-#include <vector>
-
-#include "sdk/entities/c_entity.h"
-
 namespace MafiaMP::Core::UI {
     class VehicleDebug final {
       public:

--- a/code/client/src/game/helpers/controls.h
+++ b/code/client/src/game/helpers/controls.h
@@ -15,4 +15,4 @@ namespace MafiaMP::Game::Helpers {
         static uint64_t GetLocalPlayerSpawnProfile();
         static void PlayerChangeSpawnProfile(uint64_t spawnProfile);
     };
-}
+} // namespace MafiaMP::Game::Helpers

--- a/code/client/src/game/helpers/human.cpp
+++ b/code/client/src/game/helpers/human.cpp
@@ -2,31 +2,36 @@
 
 #include <glm/glm.hpp>
 
-#include "sdk/entities/c_human_2.h"
-#include "sdk/entities/c_car.h"
-#include "sdk/entities/human/c_human_script.h"
 #include "game/overrides/character_controller.h"
+#include "sdk/entities/c_car.h"
+#include "sdk/entities/c_human_2.h"
 
 namespace MafiaMP::Game::Helpers {
-    uint8_t Human::GetHealthPercent(SDK::C_Human2 *human){
-        float fHealth = human->GetHumanScript()->GetHealth();
+    uint8_t Human::GetHealthPercent(SDK::C_Human2 *human) {
+        float fHealth    = human->GetHumanScript()->GetHealth();
         float fHealthMax = human->GetHumanScript()->GetHealthMax();
         return (uint8_t)glm::clamp(fHealth / fHealthMax, 0.0f, 100.0f);
     }
 
-    void Human::SetHealthPercent(SDK::C_Human2 *human, float health){
+    void Human::SetHealthPercent(SDK::C_Human2 *human, float health) {
         float fHealthMax = human->GetHumanScript()->GetHealthMax();
         return human->GetHumanScript()->SetHealth(glm::clamp(health * fHealthMax, 0.0f, fHealthMax));
     }
 
     bool Human::PutIntoCar(MafiaMP::Game::Overrides::CharacterController *charController, SDK::C_Car *car, int seat, bool force) {
-        if (!car) return false;
+        if (!car) {
+            return false;
+        }
+
         SDK::C_Actor *act = *(SDK::C_Actor **)((uintptr_t)car + 0xA8);
         return charController->TriggerActorAction(act, SDK::E_AA_ENTER_CAR, seat, force, false);
     }
 
     bool Human::RemoveFromCar(MafiaMP::Game::Overrides::CharacterController *charController, SDK::C_Car *car, bool force) {
-        if (!car) return false;
+        if (!car) {
+            return false;
+        }
+
         SDK::C_Actor *act = *(SDK::C_Actor **)((uintptr_t)car + 0xA8);
         return charController->TriggerActorAction(act, SDK::E_AA_LEAVE_CAR, 0, force, false);
     }
@@ -36,4 +41,4 @@ namespace MafiaMP::Game::Helpers {
 
         human->m_pHumanInventory->AddWeapon(weapon, ammo);
     }
-}
+} // namespace MafiaMP::Game::Helpers

--- a/code/client/src/sdk/c_player_teleport_module.cpp
+++ b/code/client/src/sdk/c_player_teleport_module.cpp
@@ -1,18 +1,27 @@
 #include "c_player_teleport_module.h"
 
-#include <utils/hooking/hooking.h>
 #include "patterns.h"
+#include <utils/hooking/hooking.h>
 
 namespace SDK {
     C_PlayerTeleportModule *C_PlayerTeleportModule::GetInstance() {
         return *reinterpret_cast<C_PlayerTeleportModule **>(gPatterns.C_PlayerTeleportModule__Instance);
     }
 
-    void C_PlayerTeleportModule::TeleportPlayer(ue::C_CntPtr<uintptr_t> &syncObject, ue::sys::math::C_Vector const &pos, ue::sys::math::C_Vector const &dir, bool unk1, bool unk2, bool unk3, bool unk4) {
-        hook::this_call(gPatterns.C_PlayerTeleportModule__TeleportPlayer, this, syncObject, pos, dir, unk1, unk2, unk3, unk4);
+    /**
+     * Controls are automatically locked during the transition (loading the world).
+     * If you are in a car, your car will also be teleported with you in it
+     *
+     * @param unk1
+     * @param noFadeIn - disable fade in effect
+     * @param noFadeEffects - disable fade effects (no fade in, no fade out)
+     * @param unk4
+     */
+    void C_PlayerTeleportModule::TeleportPlayer(ue::C_CntPtr<uintptr_t> &syncObject, ue::sys::math::C_Vector const &pos, ue::sys::math::C_Vector const &dir, bool unk1, bool noFadeIn, bool noFadeEffects, bool unk4) {
+        hook::this_call(gPatterns.C_PlayerTeleportModule__TeleportPlayer, this, syncObject, pos, dir, unk1, noFadeIn, noFadeEffects, unk4);
     }
 
     C_PlayerTeleportModule *GetPlayerTeleportModule() {
         return hook::call<C_PlayerTeleportModule *>(hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 83 78 38 00 74 13"));
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/entities/c_human_2.h
+++ b/code/client/src/sdk/entities/c_human_2.h
@@ -1,24 +1,25 @@
 #pragma once
 
 #include "../ai/sight/c_human_detector.h"
+#include "../c_corpse_emitter.h"
+#include "../c_weapon_emitter.h"
 #include "../game/ai/hear/c_actorear.h"
+#include "../inventory/c_inventory_wrapper.h"
 #include "../ue/c_ptr.h"
 #include "../ue/game/audio/radio/c_radio_sound.h"
-#include "../ue/game/human/c_agent.h"
-#include "../ue/game/human/c_behavior_character.h"
 #include "../ue/game/humainai/c_character_controller.h"
 #include "../ue/game/humainai/c_character_state.h"
+#include "../ue/game/human/c_agent.h"
+#include "../ue/game/human/c_behavior_character.h"
 #include "../ue/game/injury/c_injuryanalyser.h"
-#include "../ue/sys/core/c_scene_object.h"
 #include "../ue/sys/core/c_model_component.h"
+#include "../ue/sys/core/c_scene_object.h"
 #include "../ue/sys/math/c_matrix.h"
 #include "../ue/sys/math/c_vector.h"
 #include "../ue/sys/utils/c_hash_name.h"
-#include "../inventory/c_inventory_wrapper.h"
-#include "../c_corpse_emitter.h"
-#include "../c_weapon_emitter.h"
 #include "c_actor.h"
 #include "human/c_human_head_controller.h"
+#include "human/c_human_script.h"
 #include "human/c_human_weapon_controller.h"
 
 #include <cstdint>
@@ -29,47 +30,47 @@ namespace SDK {
         friend class C_HumanScript;
 
       public:
-        char pad0[0x100];                                                       // 0008 - 0108
-        ai::sight::C_HumanDetector *m_pHumanDetector;                           // 0108 - 0110
-        char pad1[0x10];                                                        // 0110 - 0120
-        game::ai::hear::C_ActorEar *m_pActorEar;                                // 0120 - 0128
-        C_InventoryWrapper *m_pHumanInventory;                                  // 0128 - 0130
-        C_HumanScript *m_pHumanScript;                                          // 0130 - 0138
-        char pad2[0x10];                                                        // 0148 - 0148
-        C_HumanWeaponController *m_pHumanWeaponController;                      // 0148 - 0150
-        ue::game::injury::C_InjuryAnalyser* m_pInjuryAnalyser;                  // 0150 - 0158
-        C_HumanHeadController *m_pHumanHeadController;                          // 0158 - 0160
-        void *m_pUnkPtr;                                                        // 0160 - 0168
-        C_CorpseEmitter *m_pCorpseEmitter;                                      // 0168 - 0170
-        char pad3[0x38];                                                        // 0170 - 01A8
-        C_WeaponEmitter *m_pWeaponEmitter;                                      // 01A8 - 01B0
-        char pad4[0x18];                                                        // 01B0 - 01C8
-        ue::game::humanai::C_CharacterState *m_pCharacterState;                 // 01C8 - 01D0
-        char pad5[0x8];                                                         // 01D0 - 01D8
-        ue::game::human::C_BehaviorCharacter *m_pBehaviorCharacter;             // 01D8 - 01E0
-        float m_fHealth;                                                        // 01E0 - 01E4
-        float m_fHealthMax;                                                     // 01E4 - 01E8
-        char pad6[0x10];                                                        // 01E8 - 01F8
-        bool m_bInvulnerable;                                                   // 01F8 - 01F9
-        char pad7[2];                                                           // 01F9 - 01FB
-        bool m_bDemigod;                                                        // 01FB - 01FC
-        char pad8[0xBC];                                                        // 01FC - 02B8
-        float field_02B8;                                                       // 02B8 - 02BC
-        float m_fWaterLevel;                                                    // 02BC - 02C0
-        bool m_bWasCarried;                                                     // 02E2 - 02E3
-        char pad9[0x65];                                                        // 02E3 - 0348
-        ue::game::human::C_Agent *m_pAgent;                                     // 0348 - 0350
-        char pad10[0x34];                                                       // 0350 - 0384
-        float m_fTransparency;                                                  // 0384 - 0388
-        char pad11[0x10];                                                       // 0388 - 0398
-        C_Entity *m_pLastGroundEntity;                                          // 0398 - 03A0
-        C_Entity *m_pInteractedEntity;                                          // 03A0 - 03A8
-        char pad12[0xD0];                                                       // 03A8 - 0478
-        ue::game::humanai::C_CharacterController *m_pCharacterController;       // 0478 - 0480
-        char pad13[0x18];                                                       // 0480 - 0498
-        ue::game::audio::radio::C_RadioSound *m_pRadioSound;                    // 0498 - 04A0
-        char pad14[0x8];                                                        // 04A0 - 04A8
-        ue::sys::core::C_ModelComponent *m_pModelComponent;                     // 04A8 - 04B0
+        char pad0[0x100];                                                 // 0008 - 0108
+        ai::sight::C_HumanDetector *m_pHumanDetector;                     // 0108 - 0110
+        char pad1[0x10];                                                  // 0110 - 0120
+        game::ai::hear::C_ActorEar *m_pActorEar;                          // 0120 - 0128
+        C_InventoryWrapper *m_pHumanInventory;                            // 0128 - 0130
+        C_HumanScript *m_pHumanScript;                                    // 0130 - 0138
+        char pad2[0x10];                                                  // 0148 - 0148
+        C_HumanWeaponController *m_pHumanWeaponController;                // 0148 - 0150
+        ue::game::injury::C_InjuryAnalyser *m_pInjuryAnalyser;            // 0150 - 0158
+        C_HumanHeadController *m_pHumanHeadController;                    // 0158 - 0160
+        void *m_pUnkPtr;                                                  // 0160 - 0168
+        C_CorpseEmitter *m_pCorpseEmitter;                                // 0168 - 0170
+        char pad3[0x38];                                                  // 0170 - 01A8
+        C_WeaponEmitter *m_pWeaponEmitter;                                // 01A8 - 01B0
+        char pad4[0x18];                                                  // 01B0 - 01C8
+        ue::game::humanai::C_CharacterState *m_pCharacterState;           // 01C8 - 01D0
+        char pad5[0x8];                                                   // 01D0 - 01D8
+        ue::game::human::C_BehaviorCharacter *m_pBehaviorCharacter;       // 01D8 - 01E0
+        float m_fHealth;                                                  // 01E0 - 01E4
+        float m_fHealthMax;                                               // 01E4 - 01E8
+        char pad6[0x10];                                                  // 01E8 - 01F8
+        bool m_bInvulnerable;                                             // 01F8 - 01F9
+        char pad7[2];                                                     // 01F9 - 01FB
+        bool m_bDemigod;                                                  // 01FB - 01FC
+        char pad8[0xBC];                                                  // 01FC - 02B8
+        float field_02B8;                                                 // 02B8 - 02BC
+        float m_fWaterLevel;                                              // 02BC - 02C0
+        bool m_bWasCarried;                                               // 02E2 - 02E3
+        char pad9[0x65];                                                  // 02E3 - 0348
+        ue::game::human::C_Agent *m_pAgent;                               // 0348 - 0350
+        char pad10[0x34];                                                 // 0350 - 0384
+        float m_fTransparency;                                            // 0384 - 0388
+        char pad11[0x10];                                                 // 0388 - 0398
+        C_Entity *m_pLastGroundEntity;                                    // 0398 - 03A0
+        C_Entity *m_pInteractedEntity;                                    // 03A0 - 03A8
+        char pad12[0xD0];                                                 // 03A8 - 0478
+        ue::game::humanai::C_CharacterController *m_pCharacterController; // 0478 - 0480
+        char pad13[0x18];                                                 // 0480 - 0498
+        ue::game::audio::radio::C_RadioSound *m_pRadioSound;              // 0498 - 04A0
+        char pad14[0x8];                                                  // 04A0 - 04A8
+        ue::sys::core::C_ModelComponent *m_pModelComponent;               // 04A8 - 04B0
 
       public:
         virtual void TickPrePhysics(float, /*ue::sys::math::C_Frustum const**/ void *, /*ue::sys::math::C_Frustum const**/ void *)           = 0;
@@ -123,46 +124,51 @@ namespace SDK {
         virtual bool IsInBoat()                                                                                                              = 0;
         virtual bool IsInVehicle()                                                                                                           = 0;
         virtual bool IsInCover()                                                                                                             = 0;
-        virtual bool IsInCoverFull(bool)                                                                                                     = 0;
-        virtual bool IsInCutscene()                                                                                                          = 0;
-        virtual void **GetRigidBody(void *)                                                                                                  = 0;
-        virtual void Spawn()                                                                                                                 = 0;
-        virtual ue::sys::math::C_Vector *GetGroundNormal()                                                                                   = 0;
-        virtual void SetTotalCollisionHeight(float)                                                                                          = 0;
-        virtual float GetTotalCollisionHeight()                                                                                              = 0;
-        virtual void UseMedkit()                                                                                                             = 0;
-        virtual void ThrowWeapon()                                                                                                           = 0;
-        virtual void SetTransparency(float)                                                                                                  = 0;
-        virtual float GetTransparency()                                                                                                      = 0;
-        virtual void SetTransparencyTarget(float)                                                                                            = 0;
-        virtual void SetMirrorVisibility(bool)                                                                                               = 0;
-        virtual void SetDirtBlend(float)                                                                                                     = 0;
-        virtual bool IsUnderScriptControl()                                                                                                  = 0;
+        /**
+         * Unlike IsInCover, IsInCoverFull will remain true if the player is aiming
+         *
+         * @param bool If false, it waits until the animation is finished before changing the value
+         */
+        virtual bool IsInCoverFull(bool)                                                   = 0;
+        virtual bool IsInCutscene()                                                        = 0;
+        virtual void **GetRigidBody(void *)                                                = 0;
+        virtual void Spawn()                                                               = 0;
+        virtual ue::sys::math::C_Vector *GetGroundNormal()                                 = 0;
+        virtual void SetTotalCollisionHeight(float)                                        = 0;
+        virtual float GetTotalCollisionHeight()                                            = 0;
+        virtual void UseMedkit()                                                           = 0;
+        virtual void ThrowWeapon()                                                         = 0;
+        virtual void SetTransparency(float)                                                = 0;
+        virtual float GetTransparency()                                                    = 0;
+        virtual void SetTransparencyTarget(float)                                          = 0;
+        virtual void SetMirrorVisibility(bool)                                             = 0;
+        virtual void SetDirtBlend(float)                                                   = 0;
+        virtual bool IsUnderScriptControl()                                                = 0;
         virtual bool DoDamage(/*C_EntityMessageDamage**/ void *, bool) = 0;
-        virtual bool IsStunAllowed()                                                                                                         = 0;
-        virtual bool AreControlsLocked()                                                                                                     = 0;
-        virtual bool IsProcessedByRender()                                                                                                   = 0;
-        virtual int64_t TimeFromProcessedByRender()                                                                                          = 0;
-        virtual bool PhysIsFalling()                                                                                                         = 0;
-        virtual bool IsSteppingOnCurb()                                                                                                      = 0;
-        virtual unsigned char __UNK_VIRTUAL_FN_1032()                                                                                        = 0;
-        virtual unsigned char __UNK_VIRTUAL_FN_1040()                                                                                        = 0;
-        virtual unsigned char __UNK_VIRTUAL_FN_1048()                                                                                        = 0;
-        virtual void DespawnHuman()                                                                                                          = 0;
-        virtual bool IsClothSimulated()                                                                                                      = 0;
-        virtual void SimulateCloth(bool, bool)                                                                                               = 0;
-        virtual void SetupHumanEnemyEmitters()                                                                                               = 0;
-        virtual bool LinkObject(uint64_t const &, ue::C_Ptr<ue::sys::core::C_SceneObject>)                                                   = 0;
-        virtual bool UnlinkObject(ue::C_Ptr<ue::sys::core::C_SceneObject>)                                                                   = 0;
-        virtual void ActivateBattleSearch()                                                                                                  = 0;
-        virtual void DeactivateBattleSearch()                                                                                                = 0; // last
+        virtual bool IsStunAllowed()                                                       = 0;
+        virtual bool AreControlsLocked()                                                   = 0;
+        virtual bool IsProcessedByRender()                                                 = 0;
+        virtual int64_t TimeFromProcessedByRender()                                        = 0;
+        virtual bool PhysIsFalling()                                                       = 0;
+        virtual bool IsSteppingOnCurb()                                                    = 0;
+        virtual unsigned char __UNK_VIRTUAL_FN_1032()                                      = 0;
+        virtual unsigned char __UNK_VIRTUAL_FN_1040()                                      = 0;
+        virtual unsigned char __UNK_VIRTUAL_FN_1048()                                      = 0;
+        virtual void DespawnHuman()                                                        = 0;
+        virtual bool IsClothSimulated()                                                    = 0;
+        virtual void SimulateCloth(bool, bool)                                             = 0;
+        virtual void SetupHumanEnemyEmitters()                                             = 0;
+        virtual bool LinkObject(uint64_t const &, ue::C_Ptr<ue::sys::core::C_SceneObject>) = 0;
+        virtual bool UnlinkObject(ue::C_Ptr<ue::sys::core::C_SceneObject>)                 = 0;
+        virtual void ActivateBattleSearch()                                                = 0;
+        virtual void DeactivateBattleSearch()                                              = 0; // last
 
       public:
         C_InventoryWrapper *GetInventoryWrapper() {
             return m_pHumanInventory;
         }
 
-        C_HumanWeaponController* GetHumanWeaponController() {
+        C_HumanWeaponController *GetHumanWeaponController() {
             return m_pHumanWeaponController;
         }
 

--- a/code/client/src/sdk/entities/human/c_human_script.cpp
+++ b/code/client/src/sdk/entities/human/c_human_script.cpp
@@ -2,8 +2,8 @@
 
 #include <utils/hooking/hooking.h>
 
-#include "../c_human_2.h"
 #include "../../c_game.h"
+#include "../c_human_2.h"
 
 #include "../../patterns.h"
 
@@ -44,7 +44,7 @@ namespace SDK {
     }
 
     bool C_HumanScript::GetInvulnerabilityByScript() const {
-        return m_pHuman->m_bDemigod;
+        return m_pHuman->m_bInvulnerable;
     }
 
     void C_HumanScript::SetInvulnerabilityByScript(bool bInvulnerabilityByScript) {
@@ -52,8 +52,7 @@ namespace SDK {
     }
 
     void C_HumanScript::GetOnVehicle(ue::C_CntPtr<uintptr_t> &outSyncObject, C_Actor *arg1, unsigned int arg2, bool arg3, bool arg4, E_HumanMoveMode moveMode, bool force) {
-        (*(void(__thiscall *)(C_HumanScript *, ue::C_CntPtr<uintptr_t> &, C_Actor *, unsigned int, bool, bool, E_HumanMoveMode, bool))gPatterns.C_HumanScript__GetOnVehicle)(
-            this, outSyncObject, arg1, arg2, arg3, arg4, moveMode, force);
+        (*(void(__thiscall *)(C_HumanScript *, ue::C_CntPtr<uintptr_t> &, C_Actor *, unsigned int, bool, bool, E_HumanMoveMode, bool))gPatterns.C_HumanScript__GetOnVehicle)(this, outSyncObject, arg1, arg2, arg3, arg4, moveMode, force);
     }
 
     void C_HumanScript::GetOffVehicle(ue::C_CntPtr<uintptr_t> &outSyncObject, C_Actor *arg1, bool arg2, bool arg3) {
@@ -72,4 +71,4 @@ namespace SDK {
     void C_HumanScript::SetStealthMove(bool move) {
         hook::this_call(gPatterns.C_HumanScript__SetStealthMove, this, move);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/entities/human/c_human_weapon_controller.cpp
+++ b/code/client/src/sdk/entities/human/c_human_weapon_controller.cpp
@@ -6,6 +6,9 @@
 #include "../../patterns.h"
 
 namespace SDK {
+    /**
+     * @param unk If false, the model does not appear, maybe for scripted weapons (like turret_truck)
+     */
     bool C_HumanWeaponController::DoWeaponSelectByItemId(unsigned int weaponId, bool unk) {
         return hook::this_call<bool>(gPatterns.C_HumanWeaponController__DoWeaponSelectByItemId, this, weaponId, unk);
     }
@@ -50,7 +53,7 @@ namespace SDK {
         hook::this_call<void>(gPatterns.C_HumanWeaponController__SetZoomFlag, this, bIsActive);
     }
 
-    bool C_HumanWeaponController::DoShot(void* unk, ue::sys::math::C_Vector* vec1, ue::sys::math::C_Vector* vec2, bool unk1, bool unk2) {
+    bool C_HumanWeaponController::DoShot(void *unk, ue::sys::math::C_Vector *vec1, ue::sys::math::C_Vector *vec2, bool unk1, bool unk2) {
         return hook::this_call<bool>(gPatterns.C_HumanWeaponController__DoShot, this, unk, vec1, vec2, unk1, unk2);
     }
 

--- a/gamemode/index.js
+++ b/gamemode/index.js
@@ -422,8 +422,7 @@ RegisterChatCommand("pos", (player, message, command, args) => {
 });
 
 RegisterChatCommand("veh", (player, message, command, args) => {
-    // const modelName = args[0] ?? "berkley_810"; // TODO: doesn't works yet
-    const modelName = "berkley_810";
+    const modelName = args[0] ?? "berkley_810";
     const veh = sdk.World.createVehicle(modelName);
 
     if (veh) {
@@ -454,8 +453,7 @@ RegisterChatCommand("plate", (player, message, command, args) => {
 RegisterChatCommand("wep", (player, message, command, args) => {
     // TODO: doesn't works yet
 
-    // const weaponId = parseInt(args[0], 10) ?? 85;
-    const weaponId = 85;
+    const weaponId = parseInt(args[0], 10) ?? 85;
     player.addWeapon(weaponId, 200);
     player.sendChat(`[SERVER] Weapon received!`);
     return;

--- a/gamemode/index.js
+++ b/gamemode/index.js
@@ -277,11 +277,11 @@ sdk.on("gamemodeLoaded", () => {
     console.log("[GAMEMODE] Gamemode loaded!");
 
     // Spawn vehicles
-    vehicleSpawns.forEach((veh) => {
+    for (const veh of vehicleSpawns) {
         const car = sdk.World.createVehicle(veh.modelName);
         car.setPosition(veh.pos);
         car.setRotation(veh.rot);
-    });
+    }
     console.log(`[GAMEMODE] spawned ${vehicleSpawns.length} vehicles!`);
 
     // Weather
@@ -305,8 +305,8 @@ sdk.on("playerConnected", (player) => {
     console.log(`[GAMEMODE] Player ${player.getNickname()} connected!`);
     player.sendChatToAll(`[SERVER] ${player.getNickname()} has joined the session!`);
 
-    player.addWeapon(2, 200); // doesn't works
-    player.setPosition(sdk.Vector3(-989.397, -289.772, 2.805)); // doesn't works
+    player.addWeapon(2, 200); // TODO: doesn't works yet
+    player.setPosition(sdk.Vector3(-989.397, -289.772, 2.805)); // TODO: doesn't works yet
     player.sendChat(`[SERVER] Welcome ${player.getNickname()}!`);
 });
 
@@ -350,7 +350,7 @@ sdk.on("chatCommand", (player, message, command, args) => {
     }
 
     if (command === "veh") {
-        // const modelName = args[0] ?? "berkley_810"; // doesn't works well yet
+        // const modelName = args[0] ?? "berkley_810"; // TODO: doesn't works well yet
         const modelName = "berkley_810";
         const veh = sdk.World.createVehicle(modelName);
 
@@ -368,7 +368,7 @@ sdk.on("chatCommand", (player, message, command, args) => {
     }
 
     if (command === "wep") {
-        // doesn't works yet
+        // TODO: doesn't works yet
 
         // const weaponId = parseInt(args[0], 10) ?? 85;
         const weaponId = 85;

--- a/gamemode/index.js
+++ b/gamemode/index.js
@@ -329,53 +329,75 @@ sdk.on("chatMessage", (player, message) => {
     sdk.Chat.sendToAll(`<${player.getNickname()}>: ${message}`);
 });
 
+const REGISTERED_CHAT_COMMANDS = new Map();
+
 sdk.on("chatCommand", (player, message, command, args) => {
     console.log(`[GAMEMODE] Player ${player.getNickname()} used: ${command}. (${message})`);
 
-    if (command === "showArgs") {
-        sdk.Chat.sendToAll(`[SERVER] Player ${player.getNickname()} used /showArgs with args: ${args}`);
-        return;
-    }
+    const foundCommand = REGISTERED_CHAT_COMMANDS.get(command);
 
-    if (command === "heal") {
-        player.setHealth(100);
-        player.sendChat(`[SERVER] Health restored!`);
-        return;
-    }
-
-    if (command === "home") {
-        player.setPosition(sdk.Vector3(-989.397, -289.772, 2.805));
-        player.sendChat(`[SERVER] Teleported to home!`);
-        return;
-    }
-
-    if (command === "veh") {
-        // const modelName = args[0] ?? "berkley_810"; // TODO: doesn't works well yet
-        const modelName = "berkley_810";
-        const veh = sdk.World.createVehicle(modelName);
-
-        if (veh) {
-            // doesn't work yet, still an object even if the vehicle doesn't exist
-            veh.setPosition(player.getPosition());
-            veh.setRotation(player.getRotation());
-
-            player.sendChat(`[SERVER] ${modelName} successfully created!`);
-            return;
-        }
-
-        player.sendChat(`[SERVER] Unable to create vehicle ${modelName}!`);
-        return;
-    }
-
-    if (command === "wep") {
-        // TODO: doesn't works yet
-
-        // const weaponId = parseInt(args[0], 10) ?? 85;
-        const weaponId = 85;
-        player.addWeapon(weaponId, 200);
-        player.sendChat(`[SERVER] Weapon received!`);
+    if (foundCommand) {
+        foundCommand(player, message, command, args);
         return;
     }
 
     sdk.Chat.sendToPlayer(player, `[SERVER] Unknown command "${command}"`);
+});
+
+function RegisterChatCommand(name, handler) {
+    REGISTERED_CHAT_COMMANDS.set(name, handler);
+}
+
+RegisterChatCommand("showArgs", (player, message, command, args) => {
+    sdk.Chat.sendToAll(`[SERVER] Player ${player.getNickname()} used /showArgs with args: ${args}`);
+});
+
+RegisterChatCommand("heal", (player, message, command, args) => {
+    player.setHealth(100);
+    player.sendChat(`[SERVER] Health restored!`);
+});
+
+RegisterChatCommand("home", (player, message, command, args) => {
+    player.setPosition(sdk.Vector3(-989.397, -289.772, 2.805));
+    player.sendChat(`[SERVER] Teleported to home!`);
+});
+
+RegisterChatCommand("veh", (player, message, command, args) => {
+    // const modelName = args[0] ?? "berkley_810"; // TODO: doesn't works yet
+    const modelName = "berkley_810";
+    const veh = sdk.World.createVehicle(modelName);
+
+    if (veh) {
+        // Condition doesn't works well yet, still an object even if the vehicle doesn't exist
+        veh.setPosition(player.getPosition());
+        veh.setRotation(player.getRotation());
+
+        player.sendChat(`[SERVER] ${modelName} successfully created!`);
+        return;
+    }
+
+    player.sendChat(`[SERVER] Unable to create vehicle ${modelName}!`);
+});
+
+RegisterChatCommand("plate", (player, message, command, args) => {
+    const veh = player.getVehicle();
+    const plate = args[0];
+
+    if (veh) {
+        veh.setLicensePlate(plate);
+        player.sendChat(`[SERVER] Plate successfully changed to ${plate}!`);
+        return;
+    }
+
+    player.sendChat(`[SERVER] You're not in a vehicle!`);
+});
+
+RegisterChatCommand("wep", (player, message, command, args) => {
+    // TODO: doesn't works yet
+
+    // const weaponId = parseInt(args[0], 10) ?? 85;
+    const weaponId = 85;
+    player.addWeapon(weaponId, 200);
+    player.sendChat(`[SERVER] Weapon received!`);
+    return;
 });

--- a/gamemode/index.js
+++ b/gamemode/index.js
@@ -1,5 +1,3 @@
-console.log("Hello from the gamemode!");
-
 const vehicleSpawns = [
     {
         modelName: "berkley_810",
@@ -273,27 +271,21 @@ const vehicleSpawns = [
     },
 ];
 
-const weatherSets = [
-    "mm_030_molotov_cp_010_cine",
-    "mm_150_boat_cp_010",
-    "mm_210_gallery_cp_050",
-];
+const weatherSets = ["mm_030_molotov_cp_010_cine", "mm_150_boat_cp_010", "mm_210_gallery_cp_050"];
 
 sdk.on("gamemodeLoaded", () => {
-    console.log('[GAMEMODE] Gamemode loaded!')
+    console.log("[GAMEMODE] Gamemode loaded!");
 
     // Spawn vehicles
-    for (const veh of vehicleSpawns) {
+    vehicleSpawns.forEach((veh) => {
         const car = sdk.World.createVehicle(veh.modelName);
         car.setPosition(veh.pos);
         car.setRotation(veh.rot);
-    }
+    });
     console.log(`[GAMEMODE] spawned ${vehicleSpawns.length} vehicles!`);
 
     // Weather
-    const selectedSet = weatherSets[
-        Math.floor(Math.random() * weatherSets.length)
-    ];
+    const selectedSet = weatherSets[Math.floor(Math.random() * weatherSets.length)];
     sdk.Environment.setWeather(selectedSet);
 
     // Clock
@@ -305,13 +297,17 @@ sdk.on("gamemodeLoaded", () => {
     }, 1000);
 });
 
+sdk.on("gamemodeUnloading", () => {
+    console.log("[GAMEMODE] Gamemode unloading!");
+});
+
 sdk.on("playerConnected", (player) => {
     console.log(`[GAMEMODE] Player ${player.getNickname()} connected!`);
     player.sendChatToAll(`[SERVER] ${player.getNickname()} has joined the session!`);
 
-    // player.addWeapon(20, 200); // TODO: Not working yet
-    player.setPosition(sdk.Vector3(-989.397, -289.772, 2.805));
-    player.sendChat(`[SERVER] Welcome ${player.getNickname()}!`)
+    player.addWeapon(2, 200); // doesn't works
+    player.setPosition(sdk.Vector3(-989.397, -289.772, 2.805)); // doesn't works
+    player.sendChat(`[SERVER] Welcome ${player.getNickname()}!`);
 });
 
 sdk.on("playerDisconnected", (player) => {
@@ -336,18 +332,50 @@ sdk.on("chatMessage", (player, message) => {
 sdk.on("chatCommand", (player, message, command, args) => {
     console.log(`[GAMEMODE] Player ${player.getNickname()} used: ${command}. (${message})`);
 
-    switch (command) {
-        case 'home':
-            player.setPosition(sdk.Vector3(-989.397, -289.772, 2.805));
-            player.sendChat(`[SERVER] Teleported to home!`)
-            break
-
-        case 'showArgs':
-            sdk.Chat.sendToAll(`[SERVER] Player ${player.getNickname()} used /showArgs with args: ${args}`);
-            break
-
-        default:
-            sdk.Chat.sendToPlayer(player, `[SERVER] Unknown command "${command}"`);
-            break
+    if (command === "showArgs") {
+        sdk.Chat.sendToAll(`[SERVER] Player ${player.getNickname()} used /showArgs with args: ${args}`);
+        return;
     }
+
+    if (command === "heal") {
+        player.setHealth(100);
+        player.sendChat(`[SERVER] Health restored!`);
+        return;
+    }
+
+    if (command === "home") {
+        player.setPosition(sdk.Vector3(-989.397, -289.772, 2.805));
+        player.sendChat(`[SERVER] Teleported to home!`);
+        return;
+    }
+
+    if (command === "veh") {
+        // const modelName = args[0] ?? "berkley_810"; // doesn't works well yet
+        const modelName = "berkley_810";
+        const veh = sdk.World.createVehicle(modelName);
+
+        if (veh) {
+            // doesn't work yet, still an object even if the vehicle doesn't exist
+            veh.setPosition(player.getPosition());
+            veh.setRotation(player.getRotation());
+
+            player.sendChat(`[SERVER] ${modelName} successfully created!`);
+            return;
+        }
+
+        player.sendChat(`[SERVER] Unable to create vehicle ${modelName}!`);
+        return;
+    }
+
+    if (command === "wep") {
+        // doesn't works yet
+
+        // const weaponId = parseInt(args[0], 10) ?? 85;
+        const weaponId = 85;
+        player.addWeapon(weaponId, 200);
+        player.sendChat(`[SERVER] Weapon received!`);
+        return;
+    }
+
+    sdk.Chat.sendToPlayer(player, `[SERVER] Unknown command "${command}"`);
 });


### PR DESCRIPTION
### Main
- Introduce  Player Debug UI

#### Also
- Cleanup dev features
- EntityBrowser UI, Vehicle Debug UI, Debug window can now be closed
- Improve UX for pos, dir, rot debug sliders
- Import `sdk/entities/human/c_human_script.h` in `sdk/entities/c_human_2.h` (cleanup files which import both)
- Remove `sdk/entities/c_human_2.h` import when `sdk/entities/c_player_2.h` is already imported
- Remove automatic weapon giving when human is created or setup
- Fix `C_HumanScript::GetInvulnerabilityByScript`
- Documentation for `C_PlayerTeleportModule::TeleportPlayer` known parameters
- Documentation for `C_Human2::IsInCoverFull`
- Documentation for `C_HumanWeaponController::DoWeaponSelectByItemId`

#### Known issues
- `SetScale` needs a single float but `GetScale` returns a `Vector3` => https://github.com/MafiaHub/MafiaMP/issues/49
- We can't kill a player => https://github.com/MafiaHub/MafiaMP/issues/52
- SDK `Player.addWeapon` doesn't works => https://github.com/MafiaHub/MafiaMP/issues/51
- ~~SDK Player.setPosition doesn't works in the event playerConnected => https://github.com/MafiaHub/MafiaMP/issues/45~~
- ~~SDK chat `args[0]`  is the command name when there is no args => https://github.com/MafiaHub/MafiaMP/issues/50~~
- SDK `sdk.World.createVehicle` returns an object even when the vehicle doesn't exists

I will create specific tickets for these issues.