### PR TITLE
 Cleanup patterns

### DIFF
--- a/code/client/src/core/dev_features.cpp
+++ b/code/client/src/core/dev_features.cpp
@@ -14,6 +14,7 @@
 #include "game/helpers/controls.h"
 #include "game/helpers/human.h"
 #include "game/streaming/entity_factory.h"
+
 #include "sdk/c_game_traffic_module.h"
 #include "sdk/entities/c_car.h"
 #include "sdk/entities/c_crash_obj.h"
@@ -39,6 +40,10 @@
 #include "../sdk/mafia/framework/c_vehicles_database.h"
 #include "../sdk/ue/sys/sodb/c_sys_odb.h"
 #include "modules/human.h"
+
+#include "sdk/mafia/framework/c_mafia_dbs.h"
+#include "sdk/mafia/framework/c_vehicles_database.h"
+#include "sdk/ue/sys/sodb/c_sys_odb.h"
 
 namespace MafiaMP::Core {
     DevFeatures::DevFeatures() {

--- a/code/client/src/core/dev_features.cpp
+++ b/code/client/src/core/dev_features.cpp
@@ -36,9 +36,6 @@
 
 #include "shared/game_rpc/human/human_changeskin.h"
 
-#include "../sdk/mafia/framework/c_mafia_dbs.h"
-#include "../sdk/mafia/framework/c_vehicles_database.h"
-#include "../sdk/ue/sys/sodb/c_sys_odb.h"
 #include "modules/human.h"
 
 #include "sdk/mafia/framework/c_mafia_dbs.h"

--- a/code/client/src/core/hooks/application.cpp
+++ b/code/client/src/core/hooks/application.cpp
@@ -1,7 +1,7 @@
 #include <MinHook.h>
 #include <utils/hooking/hook_function.h>
 
-#include "../../sdk/patterns.h"
+#include "sdk/patterns.h"
 
 bool __fastcall C_GameFramework__IsSuspended(void *_this) {
     return false;

--- a/code/client/src/core/hooks/application.cpp
+++ b/code/client/src/core/hooks/application.cpp
@@ -1,6 +1,5 @@
 #include <MinHook.h>
 #include <utils/hooking/hook_function.h>
-#include <utils/hooking/hooking.h>
 
 #include "../../sdk/patterns.h"
 
@@ -10,5 +9,5 @@ bool __fastcall C_GameFramework__IsSuspended(void *_this) {
 
 static InitFunction init([]() {
     // Don't pause the game when out of window
-    MH_CreateHook((LPVOID)SDK::gPatterns.C_GameFramework__IsSuspendedAddr, (PBYTE)&C_GameFramework__IsSuspended, nullptr);
+    MH_CreateHook((LPVOID)SDK::gPatterns.C_GameFramework__IsSuspended, (PBYTE)&C_GameFramework__IsSuspended, nullptr);
 });

--- a/code/client/src/core/hooks/character_controller.cpp
+++ b/code/client/src/core/hooks/character_controller.cpp
@@ -2,10 +2,10 @@
 #include <utils/hooking/hook_function.h>
 #include <utils/hooking/hooking.h>
 
-#include "../../sdk/c_ie.h"
-#include "../../sdk/entities/c_player_2.h"
-#include "../../sdk/ue/game/humainai/c_character_controller.h"
-#include "../../sdk/c_game.h"
+#include "sdk/c_ie.h"
+#include "sdk/entities/c_player_2.h"
+#include "sdk/ue/game/humainai/c_character_controller.h"
+#include "sdk/c_game.h"
 
 #include "../../game/overrides/character_controller.h"
 #include "../../game/overrides/scoped_entity_type_faker.h"

--- a/code/client/src/core/hooks/fast_load.cpp
+++ b/code/client/src/core/hooks/fast_load.cpp
@@ -2,8 +2,8 @@
 #include <utils/hooking/hooking.h>
 #include <utils/hooking/hook_function.h>
 
-#include "../../sdk/mafia/ui/c_game_gui_2_module.h"
-#include "../../sdk/mafia/ui/menu/c_save_menu.h"
+#include "sdk/mafia/ui/c_game_gui_2_module.h"
+#include "sdk/mafia/ui/menu/c_save_menu.h"
 
 void __fastcall C_MainMenu__QueueMenuSequenceScreen(void *_this, int sequence, bool cannotSkip) {
     if (sequence == -1) {

--- a/code/client/src/core/hooks/hud.cpp
+++ b/code/client/src/core/hooks/hud.cpp
@@ -6,7 +6,7 @@
 
 #include <logging/logger.h>
 
-#include "../../sdk/mafia/ui/menu/c_menu_base.h"
+#include "sdk/mafia/ui/menu/c_menu_base.h"
 
 typedef int64_t(__fastcall *C_MenuBase__OnScriptedMenuEvent_t)(void *pThis, int, SDK::mafia::ui::menu::C_MenuBase::E_ScriptedMenuEvent);
 C_MenuBase__OnScriptedMenuEvent_t C_MenuBase__OnScriptedMenuEvent_original = nullptr;

--- a/code/client/src/core/hooks/mod_init.cpp
+++ b/code/client/src/core/hooks/mod_init.cpp
@@ -1,5 +1,5 @@
 #include "../../game/module.h"
-#include "../../sdk/patterns.h"
+#include "sdk/patterns.h"
 
 #include <MinHook.h>
 #include <utils/hooking/hook_function.h>

--- a/code/client/src/core/hooks/mod_init.cpp
+++ b/code/client/src/core/hooks/mod_init.cpp
@@ -2,7 +2,6 @@
 #include "../../sdk/patterns.h"
 
 #include <MinHook.h>
-#include <utils/hooking/hooking.h>
 #include <utils/hooking/hook_function.h>
 
 // Ticked module hooking
@@ -13,7 +12,7 @@ void __fastcall C_InitDone__MafiaFramework(void *_this) {
     MafiaMP::Game::gGlobals.module = new MafiaMP::Game::ModModule();
 }
 
-// Intro vide hooking
+// Intro video hooking
 int __fastcall C_CommandLine__FindCommand(void *_this, const char *command) {
     if (strstr(command, "NoMy2K") || strstr(command, "SkipLoadingPrompt") /*|| strstr(command, "fastRender")*/) {
         return 1;
@@ -22,11 +21,11 @@ int __fastcall C_CommandLine__FindCommand(void *_this, const char *command) {
 }
 
 static InitFunction init([]() {
-    MH_CreateHook((LPVOID)SDK::gPatterns.C_InitDone_MafiaFrameworkAddr, (PBYTE)C_InitDone__MafiaFramework, reinterpret_cast<void **>(&C_InitDone__Init_MafiaFramework_original));
+    MH_CreateHook((LPVOID)SDK::gPatterns.C_InitDone_MafiaFramework, (PBYTE)C_InitDone__MafiaFramework, reinterpret_cast<void **>(&C_InitDone__Init_MafiaFramework_original));
 
     // Disable the loading intro
-    hook::return_function(SDK::gPatterns.LoadIntroAddr);
+    hook::return_function(SDK::gPatterns.LoadIntro);
 
     // Skip loading prompt & debug stuff
-    MH_CreateHook((LPVOID)SDK::gPatterns.C_CommandLine__FindCommandAddr, (PBYTE)C_CommandLine__FindCommand, nullptr);
+    MH_CreateHook((LPVOID)SDK::gPatterns.C_CommandLine__FindCommand, (PBYTE)C_CommandLine__FindCommand, nullptr);
 });

--- a/code/client/src/core/hooks/navigation.cpp
+++ b/code/client/src/core/hooks/navigation.cpp
@@ -1,13 +1,17 @@
 #include <utils/safe_win32.h>
+
 #include <MinHook.h>
+
 #include <utils/hooking/hook_function.h>
 #include <utils/hooking/hooking.h>
 
 #include <logging/logger.h>
 
 #include "../application.h"
+
 #include "../../game/helpers/districts.h"
-#include "../../sdk/mafia/framework/director/c_game_director.h"
+
+#include "sdk/mafia/framework/director/c_game_director.h"
 
 typedef int64_t(__fastcall *C_Navigation__OnDistrictChange_t)(void *, SDK::mafia::framework::director::I_GameDirector::C_DistrictDefinition const &);
 C_Navigation__OnDistrictChange_t C_Navigation__OnDistrictChange_original = nullptr;

--- a/code/client/src/core/hooks/player.cpp
+++ b/code/client/src/core/hooks/player.cpp
@@ -4,8 +4,8 @@
 
 #include <logging/logger.h>
 
-#include "../../sdk/entities/c_player_2.h"
-#include "../../sdk/c_game.h"
+#include "sdk/entities/c_player_2.h"
+#include "sdk/c_game.h"
 
 typedef bool(__fastcall *C_Player2__IsInputDisabled_t)(SDK::C_Player2 *, int);
 C_Player2__IsInputDisabled_t C_Player2__IsInputDisabled_Original = nullptr;

--- a/code/client/src/core/hooks/render_device.cpp
+++ b/code/client/src/core/hooks/render_device.cpp
@@ -13,11 +13,11 @@
 
 #include "../../game/module.h"
 
-#include "../../sdk/ue/c_application_win32.h"
-#include "../../sdk/ue/sys/render/device/c_d3d11_window_context_cache.h"
-#include "../../sdk/ue/sys/render/device/c_direct_3d11_render_device.h"
-#include "../../sdk/ue/sys/render/device/c_dynamic_vi_buffer_pool.h"
-#include "../../sdk/ue/sys/render/device/s_render_device_desc.h"
+#include "sdk/ue/c_application_win32.h"
+#include "sdk/ue/sys/render/device/c_d3d11_window_context_cache.h"
+#include "sdk/ue/sys/render/device/c_direct_3d11_render_device.h"
+#include "sdk/ue/sys/render/device/c_dynamic_vi_buffer_pool.h"
+#include "sdk/ue/sys/render/device/s_render_device_desc.h"
 
 typedef bool(__fastcall *C_Direct3D11RenderDevice__Init_t)(SDK::ue::sys::render::device::C_Direct3D11RenderDevice *pThis, SDK::ue::sys::render::device::S_RenderDeviceDesc const &a2, SDK::ue::sys::render::device::C_DynamicVIBufferPool &a3, void *idk);
 C_Direct3D11RenderDevice__Init_t C_Direct3D11RenderDevice__Init_original = nullptr;

--- a/code/client/src/core/hooks/slot_wrapper.cpp
+++ b/code/client/src/core/hooks/slot_wrapper.cpp
@@ -4,19 +4,19 @@
 
 #include <logging/logger.h>
 
-#include "../../sdk/ue/sys/core/c_frame.h"
-#include "../../sdk/ue/sys/core/c_scene.h"
-#include "../../sdk/ue/sys/math/c_vector.h"
+#include "sdk/ue/sys/core/c_frame.h"
+#include "sdk/ue/sys/core/c_scene.h"
+#include "sdk/ue/sys/math/c_vector.h"
 
-#include "../../sdk/mafia/streaming/c_slot_wrapper.h"
+#include "sdk/mafia/streaming/c_slot_wrapper.h"
 
-#include "../../sdk/entities/c_actor.h"
-#include "../../sdk/ue/sys/utils/c_hash_name.h"
+#include "sdk/entities/c_actor.h"
+#include "sdk/ue/sys/utils/c_hash_name.h"
 
 typedef bool(__fastcall *C_SlotManagerWrapper__ConnectToQuota_t)(void *, SDK::mafia::streaming::I_SlotWrapper *, char const *, int, int);
 C_SlotManagerWrapper__ConnectToQuota_t C_SlotManagerWrapper__ConnectToQuota_original = nullptr;
 
-bool C_SlotManagerWrapper__ConnectToQuota(void* pThis, SDK::mafia::streaming::I_SlotWrapper* slotWrapper, char const* name, int slotType, int unk) {
+bool C_SlotManagerWrapper__ConnectToQuota(void *pThis, SDK::mafia::streaming::I_SlotWrapper *slotWrapper, char const *name, int slotType, int unk) {
     // Framework::Logging::GetLogger("Hooks")->debug("[Wrapper] Connected to quota {} for slot type {} and unk {} ({})", name, slotType, unk, slotWrapper->GetWrapperName());
     return C_SlotManagerWrapper__ConnectToQuota_original(pThis, slotWrapper, name, slotType, unk);
 }
@@ -24,7 +24,7 @@ bool C_SlotManagerWrapper__ConnectToQuota(void* pThis, SDK::mafia::streaming::I_
 typedef int64_t(__fastcall *C_SlotManagerWrapper__LoadData_t)(void *, char const *, SDK::ue::sys::core::C_Scene *, unsigned int, char const *, bool *, bool);
 C_SlotManagerWrapper__LoadData_t C_SlotManagerWrapper__LoadData_original = nullptr;
 
-int64_t C_SlotManagerWrapper__LoadData(void* pThis, char const* sdsName, SDK::ue::sys::core::C_Scene* scene, unsigned int unk, char const* dataName, bool* unk2, bool unk3) {
+int64_t C_SlotManagerWrapper__LoadData(void *pThis, char const *sdsName, SDK::ue::sys::core::C_Scene *scene, unsigned int unk, char const *dataName, bool *unk2, bool unk3) {
     // Framework::Logging::GetLogger("Hooks")->debug("[Wrapper] Loaded data = {} | {} | {}", sdsName, unk, dataName);
     return C_SlotManagerWrapper__LoadData_original(pThis, sdsName, scene, unk, dataName, unk2, unk3);
 }
@@ -32,7 +32,7 @@ int64_t C_SlotManagerWrapper__LoadData(void* pThis, char const* sdsName, SDK::ue
 typedef int64_t(__fastcall *C_Slot__LoadData_t)(void *, char const *, SDK::ue::sys::core::C_Scene *, unsigned int, void *, char const *, bool *, bool);
 C_Slot__LoadData_t C_Slot__LoadData_original = nullptr;
 
-int64_t C_Slot__LoadData(void *pThis, char const *sdsName, SDK::ue::sys::core::C_Scene *scene, unsigned int unk, void * unkPtr, char const *dataName, bool *unk2, bool unk3) {
+int64_t C_Slot__LoadData(void *pThis, char const *sdsName, SDK::ue::sys::core::C_Scene *scene, unsigned int unk, void *unkPtr, char const *dataName, bool *unk2, bool unk3) {
     // Framework::Logging::GetLogger("Hooks")->debug("Loaded data = {} | {} | {}", sdsName, unk, dataName);
     return C_Slot__LoadData_original(pThis, sdsName, scene, unk, unkPtr, dataName, unk2, unk3);
 }

--- a/code/client/src/core/hooks/stream_map.cpp
+++ b/code/client/src/core/hooks/stream_map.cpp
@@ -1,8 +1,8 @@
 #include <MinHook.h>
 #include <utils/hooking/hook_function.h>
 
-#include "../../sdk/c_stream_map.h"
-#include "../../sdk/patterns.h"
+#include "sdk/c_stream_map.h"
+#include "sdk/patterns.h"
 
 #include <logging/logger.h>
 

--- a/code/client/src/core/hooks/stream_map.cpp
+++ b/code/client/src/core/hooks/stream_map.cpp
@@ -1,8 +1,9 @@
 #include <MinHook.h>
 #include <utils/hooking/hook_function.h>
 
-#include "sdk/c_stream_map.h"
 #include "sdk/patterns.h"
+
+#include "sdk/c_stream_map.h"
 
 #include <logging/logger.h>
 

--- a/code/client/src/core/hooks/stream_map.cpp
+++ b/code/client/src/core/hooks/stream_map.cpp
@@ -1,9 +1,8 @@
 #include <MinHook.h>
 #include <utils/hooking/hook_function.h>
-#include <utils/hooking/hooking.h>
 
-#include "../../sdk/patterns.h"
 #include "../../sdk/c_stream_map.h"
+#include "../../sdk/patterns.h"
 
 #include <logging/logger.h>
 

--- a/code/client/src/core/hooks/translocator.cpp
+++ b/code/client/src/core/hooks/translocator.cpp
@@ -4,7 +4,7 @@
 
 #include <logging/logger.h>
 
-#include "../../sdk/ue/sys/math/c_vector.h"
+#include "sdk/ue/sys/math/c_vector.h"
 
 struct S_ObjectToSpawn {
     char pad0[0x10];

--- a/code/client/src/core/hooks/vehicle.cpp
+++ b/code/client/src/core/hooks/vehicle.cpp
@@ -9,11 +9,11 @@
 #include "../modules/vehicle.h"
 #include "shared/modules/vehicle_sync.hpp"
 
-#include "../../sdk/entities/c_actor.h"
-#include "../../sdk/entities/c_car.h"
-#include "../../sdk/entities/c_human_2.h"
-#include "../../sdk/entities/c_vehicle.h"
-#include "../../sdk/wrappers/c_human_2_car_wrapper.h"
+#include "sdk/entities/c_actor.h"
+#include "sdk/entities/c_car.h"
+#include "sdk/entities/c_human_2.h"
+#include "sdk/entities/c_vehicle.h"
+#include "sdk/wrappers/c_human_2_car_wrapper.h"
 
 SDK::C_Actor* C_ActorAction__GetOwnerAsActor(void *pThis) {
     return hook::this_call<SDK::C_Actor *>(0x0000001423434E0, pThis);
@@ -127,7 +127,7 @@ void C_Human2CarWrapper__EndDrive(SDK::C_Human2CarWrapper *pThis, SDK::C_Actor *
     }
 }
 
-static InitFunction init([]() {    
+static InitFunction init([]() {
     // Disable automated vehicle enable (engine, siren, beacon lights etc...) when player enter it
     const auto C_Human2CarWrapper__StartDrive_Addr = hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 56 57 41 57 48 83 EC 70 45 33 FF").get_first();
     MH_CreateHook((LPVOID)C_Human2CarWrapper__StartDrive_Addr, (PBYTE)C_Human2CarWrapper__StartDrive, reinterpret_cast<void **>(&C_Human2CarWrapper__StartDrive_original));

--- a/code/client/src/core/hooks/vfs.h
+++ b/code/client/src/core/hooks/vfs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../sdk/ue/sys/filesystem/c_virtual_file_system_cache.h"
+#include "sdk/ue/sys/filesystem/c_virtual_file_system_cache.h"
 
 struct S_Init {
 

--- a/code/client/src/core/luavm.cpp
+++ b/code/client/src/core/luavm.cpp
@@ -3,7 +3,6 @@
 
 #include <MinHook.h>
 #include <logging/logger.h>
-#include <utils/hooking/hooking.h>
 
 #include <sstream>
 
@@ -12,7 +11,7 @@
 using namespace SDK;
 
 namespace MafiaMP::Core {
-    using lua_State = void;
+    using lua_State       = void;
     lua_State *g_luaState = nullptr;
 
     typedef int32_t(__cdecl *lua_pcall_t)(lua_State *L, int32_t nargs, int32_t nresults, int32_t errfunc);
@@ -85,9 +84,9 @@ namespace MafiaMP::Core {
     }
 
     static InitFunction init([]() {
-        MH_CreateHook(reinterpret_cast<void **>(gPatterns.Lua__pcallAddr), reinterpret_cast<void **>(lua_pcall_), reinterpret_cast<void **>(&plua_pcall));
-        MH_CreateHook(reinterpret_cast<void **>(gPatterns.Lua__loadbufferAddr), reinterpret_cast<void **>(luaL_loadbuffer_), reinterpret_cast<void **>(&pluaL_loadbuffer));
-        MH_CreateHook(reinterpret_cast<void **>(gPatterns.Lua__tostringAddr), reinterpret_cast<void **>(lua_tostring_), reinterpret_cast<void **>(&plua_tostring));
-        MH_CreateHook(reinterpret_cast<void **>(gPatterns.Lua__isstringAddr), reinterpret_cast<void **>(lua_isstring_), reinterpret_cast<void **>(&plua_isstring));
+        MH_CreateHook(reinterpret_cast<void **>(gPatterns.Lua__pcall), reinterpret_cast<void **>(lua_pcall_), reinterpret_cast<void **>(&plua_pcall));
+        MH_CreateHook(reinterpret_cast<void **>(gPatterns.Lua__loadbuffer), reinterpret_cast<void **>(luaL_loadbuffer_), reinterpret_cast<void **>(&pluaL_loadbuffer));
+        MH_CreateHook(reinterpret_cast<void **>(gPatterns.Lua__tostring), reinterpret_cast<void **>(lua_tostring_), reinterpret_cast<void **>(&plua_tostring));
+        MH_CreateHook(reinterpret_cast<void **>(gPatterns.Lua__isstring), reinterpret_cast<void **>(lua_isstring_), reinterpret_cast<void **>(&plua_isstring));
     });
 } // namespace MafiaMP::Core

--- a/code/client/src/core/luavm.cpp
+++ b/code/client/src/core/luavm.cpp
@@ -1,4 +1,5 @@
 #include "luavm.h"
+
 #include "sdk/patterns.h"
 
 #include <MinHook.h>

--- a/code/client/src/core/luavm.cpp
+++ b/code/client/src/core/luavm.cpp
@@ -1,5 +1,5 @@
 #include "luavm.h"
-#include "../sdk/patterns.h"
+#include "sdk/patterns.h"
 
 #include <MinHook.h>
 #include <logging/logger.h>

--- a/code/client/src/core/states/initialize.cpp
+++ b/code/client/src/core/states/initialize.cpp
@@ -2,7 +2,7 @@
 
 #include "states.h"
 
-#include "../../sdk/c_game.h"
+#include "sdk/c_game.h"
 
 #include <utils/states/machine.h>
 

--- a/code/client/src/core/states/menu.cpp
+++ b/code/client/src/core/states/menu.cpp
@@ -8,8 +8,9 @@
 
 #include "../../game/helpers/camera.h"
 #include "../../game/helpers/controls.h"
-#include "../../sdk/mafia/framework/c_mafia_framework.h"
-#include "../../sdk/mafia/framework/c_mafia_framework_interfaces.h"
+
+#include "sdk/mafia/framework/c_mafia_framework.h"
+#include "sdk/mafia/framework/c_mafia_framework_interfaces.h"
 
 #include "../application.h"
 

--- a/code/client/src/core/ui/vehicle_debug.cpp
+++ b/code/client/src/core/ui/vehicle_debug.cpp
@@ -1,12 +1,12 @@
 #include "vehicle_debug.h"
+
 #include <external/imgui/wrapper.h>
 #include <imgui.h>
 
-#include "../../sdk/entities/c_car.h"
-#include "../../sdk/entities/c_player_2.h"
-#include "../../sdk/entities/c_vehicle.h"
-
-#include "../../sdk/ue/sys/math/c_vector.h"
+#include "sdk/entities/c_car.h"
+#include "sdk/entities/c_player_2.h"
+#include "sdk/entities/c_vehicle.h"
+#include "sdk/ue/sys/math/c_vector.h"
 
 #include "game/helpers/controls.h"
 

--- a/code/client/src/game/entities/factory.h
+++ b/code/client/src/game/entities/factory.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "../../sdk/ue/sys/core/i_core.h"
-#include "../../sdk/ue/sys/core/c_core.h"
-#include "../../sdk/ue/sys/core/c_frame.h"
+#include "sdk/ue/sys/core/i_core.h"
+#include "sdk/ue/sys/core/c_core.h"
+#include "sdk/ue/sys/core/c_frame.h"
 
 namespace MafiaMP::Game::Entities {
     class Factory {

--- a/code/client/src/game/helpers/camera.cpp
+++ b/code/client/src/game/helpers/camera.cpp
@@ -5,7 +5,8 @@
 #include "../../core/application.h"
 
 #include "controls.h"
-#include "../../sdk/ue/game/camera/c_game_camera.h"
+
+#include "sdk/ue/game/camera/c_game_camera.h"
 
 namespace MafiaMP::Game::Helpers {
     bool Camera::SetFPV(bool toggle) {
@@ -57,4 +58,4 @@ namespace MafiaMP::Game::Helpers {
     bool Camera::SimpleShake() {
         return true;
     }
-}
+} // namespace MafiaMP::Game::Helpers

--- a/code/client/src/game/helpers/camera.h
+++ b/code/client/src/game/helpers/camera.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../sdk/ue/sys/math/c_vector.h"
+#include "sdk/ue/sys/math/c_vector.h"
 
 namespace MafiaMP::Game::Helpers {
     class Camera {
@@ -8,7 +8,7 @@ namespace MafiaMP::Game::Helpers {
         static bool SetFPV(bool);
         static bool SetPos(SDK::ue::sys::math::C_Vector, SDK::ue::sys::math::C_Vector, bool);
         static bool ResetBehindPlayer();
-        
+
         static bool SimpleShake();
     };
 }

--- a/code/client/src/game/helpers/controls.cpp
+++ b/code/client/src/game/helpers/controls.cpp
@@ -1,13 +1,14 @@
 #include "controls.h"
 
-#include "../../sdk/mafia/framework/c_mafia_framework_interfaces.h"
-#include "../../sdk/mafia/framework/c_mafia_framework.h"
+#include "sdk/mafia/framework/c_mafia_framework_interfaces.h"
 
-#include "../../sdk/c_game_input_module.h"
-#include "../../sdk/entities/c_player_2.h"
+#include "sdk/mafia/framework/c_mafia_framework.h"
+
+#include "sdk/c_game_input_module.h"
+#include "sdk/entities/c_player_2.h"
 
 namespace MafiaMP::Game::Helpers {
-    SDK::C_Player2* Controls::GetLocalPlayer() {
+    SDK::C_Player2 *Controls::GetLocalPlayer() {
         SDK::mafia::framework::C_MafiaFramework *pMafiaFramework = SDK::mafia::framework::C_MafiaFramework::GetInstance();
         if (!pMafiaFramework) {
             return nullptr;
@@ -95,4 +96,4 @@ namespace MafiaMP::Game::Helpers {
 
         playerModelManager->SwitchSpawnProfile(spawnProfile);
     }
-}
+} // namespace MafiaMP::Game::Helpers

--- a/code/client/src/game/module.cpp
+++ b/code/client/src/game/module.cpp
@@ -1,10 +1,10 @@
 #include "module.h"
 
-#include "../sdk/c_game.h"
-#include "../sdk/entities/c_car.h"
-#include "../sdk/entities/c_player_2.h"
-#include "../sdk/entities/c_vehicle.h"
-#include "../sdk/entities/human/c_human_weapon_controller.h"
+#include "sdk/c_game.h"
+#include "sdk/entities/c_car.h"
+#include "sdk/entities/c_player_2.h"
+#include "sdk/entities/c_vehicle.h"
+#include "sdk/entities/human/c_human_weapon_controller.h"
 
 #include <SDL2/SDL.h>
 #include <logging/logger.h>

--- a/code/client/src/game/module.h
+++ b/code/client/src/game/module.h
@@ -4,12 +4,13 @@
 
 #include "../core/application.h"
 
-#include "../sdk/c_ticked_module.h"
-#include "../sdk/c_ticked_module_manager.h"
+#include "sdk/c_ticked_module.h"
+#include "sdk/c_ticked_module_manager.h"
 
-#include "../sdk/ue/sys/render/device/c_direct_3d11_render_device.h"
+#include "sdk/ue/sys/render/device/c_direct_3d11_render_device.h"
 
 #include <functional>
+
 #include <Windows.h>
 
 #include <dxgi.h>

--- a/code/client/src/game/overrides/character_controller.cpp
+++ b/code/client/src/game/overrides/character_controller.cpp
@@ -1,6 +1,6 @@
 #include "character_controller.h"
 
-#include "../../sdk/c_ie.h"
+#include "sdk/c_ie.h"
 
 #include "scoped_entity_type_faker.h"
 

--- a/code/client/src/game/overrides/character_controller.h
+++ b/code/client/src/game/overrides/character_controller.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "../../sdk/entities/c_human_2.h"
-#include "../../sdk/ue/game/humainai/c_character_controller.h"
-#include "../../sdk/ue/game/humainai/c_character_state_handler.h"
-#include "../../sdk/ue/game/humainai/c_character_state_handler_base_locomotion.h"
-#include "../../sdk/ue/game/humainai/c_character_state_handler_move.h"
+#include "sdk/entities/c_human_2.h"
+#include "sdk/ue/game/humainai/c_character_controller.h"
+#include "sdk/ue/game/humainai/c_character_state_handler.h"
+#include "sdk/ue/game/humainai/c_character_state_handler_base_locomotion.h"
+#include "sdk/ue/game/humainai/c_character_state_handler_move.h"
 
 extern thread_local bool CreateNetCharacterController;
 

--- a/code/client/src/game/overrides/scoped_entity_type_faker.h
+++ b/code/client/src/game/overrides/scoped_entity_type_faker.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../sdk/entities/c_entity.h"
+#include "sdk/entities/c_entity.h"
 
 namespace MafiaMP::Game::Overrides {
     struct ScopedEntityTypeFaker {

--- a/code/client/src/game/streaming/entity_factory.h
+++ b/code/client/src/game/streaming/entity_factory.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "../../sdk/entities/c_entity.h"
-#include "../../sdk/mafia/streaming/c_actors_slot_wrapper.h"
-#include "../../sdk/ue/game/traffic/c_human_spawner.h"
-#include "../../sdk/ue/sys/utils/c_hash_name.h"
+#include "sdk/entities/c_entity.h"
+#include "sdk/mafia/streaming/c_actors_slot_wrapper.h"
+#include "sdk/ue/game/traffic/c_human_spawner.h"
+#include "sdk/ue/sys/utils/c_hash_name.h"
+
 #include "entity_type_factory.h"
 
-#include <string>
 #include <functional>
+#include <string>
 
 namespace MafiaMP::Game::Streaming {
     class EntityFactory {

--- a/code/client/src/game/streaming/entity_tracking_info.h
+++ b/code/client/src/game/streaming/entity_tracking_info.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "../../sdk/entities/c_entity.h"
+#include "sdk/entities/c_entity.h"
 
 #include <functional>
 
 #include <flecs/flecs.h>
-
 
 namespace MafiaMP::Game::Streaming {
     class EntityTrackingInfo {
@@ -13,9 +12,10 @@ namespace MafiaMP::Game::Streaming {
         friend class EntityTypeFactory;
 
       public:
-        using BeforeSpawnCallback   = std::function<void(EntityTrackingInfo*)>;
-        using RequestFinishCallback = std::function<void(EntityTrackingInfo*, bool)>;
-        using ReturnCallback        = std::function<void(EntityTrackingInfo*, bool)>;
+        using BeforeSpawnCallback   = std::function<void(EntityTrackingInfo *)>;
+        using RequestFinishCallback = std::function<void(EntityTrackingInfo *, bool)>;
+        using ReturnCallback        = std::function<void(EntityTrackingInfo *, bool)>;
+
       private:
         SDK::E_EntityType _type;
         SDK::C_Entity *_entity = nullptr;

--- a/code/client/src/game/streaming/entity_type_factory.h
+++ b/code/client/src/game/streaming/entity_type_factory.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "../../sdk/entities/c_entity.h"
+#include "sdk/entities/c_entity.h"
+
 #include "entity_tracking_info.h"
 
 #include <list>
@@ -25,7 +26,7 @@ namespace MafiaMP::Game::Streaming {
 
             ExtendedTrackingInfo(SDK::E_EntityType entityType, Kind entityKind): _kind(entityKind), _info(std::make_unique<EntityTrackingInfo>(entityType)) {}
             ExtendedTrackingInfo(ExtendedTrackingInfo &&other): _kind(other._kind), _info(std::exchange(other._info, nullptr)) {}
-            ExtendedTrackingInfo(ExtendedTrackingInfo &) = delete;
+            ExtendedTrackingInfo(ExtendedTrackingInfo &)            = delete;
             ExtendedTrackingInfo &operator=(ExtendedTrackingInfo &) = delete;
 
             Kind GetKind() const {
@@ -40,11 +41,8 @@ namespace MafiaMP::Game::Streaming {
             std::list<ExtendedTrackingInfo> _createdEntities;
 
             SpawnerWrap(Spawner *spawner): _spawner(spawner) {}
-            SpawnerWrap(SpawnerWrap &&other)
-                : _spawner(std::exchange(other._spawner, nullptr))
-                , _state(std::exchange(other._state, EntitySpawnerState::Loading))
-                , _ongoingRequests(std::move(other._ongoingRequests)) {}
-            SpawnerWrap(SpawnerWrap &) = delete;
+            SpawnerWrap(SpawnerWrap &&other): _spawner(std::exchange(other._spawner, nullptr)), _state(std::exchange(other._state, EntitySpawnerState::Loading)), _ongoingRequests(std::move(other._ongoingRequests)) {}
+            SpawnerWrap(SpawnerWrap &)            = delete;
             SpawnerWrap &operator=(SpawnerWrap &) = delete;
 
             EntitySpawnerState GetState() const {
@@ -66,15 +64,14 @@ namespace MafiaMP::Game::Streaming {
         std::unordered_map<EntityTrackingInfo *, SpawnerWrap *> _trackingInfos;
 
       public:
-        EntityTypeFactory(SpawnerCreateFn createSpawnerFn, SpawnerProcessLoadFn spawnerProcessLoadFn, SpawnerSpawnEntityFn spawnEntityFn,
-            SpawnerReturnEntityFn returnEntityToSpawnerFn, SpawnerDestroyFn destroySpawnerFn)
+        EntityTypeFactory(SpawnerCreateFn createSpawnerFn, SpawnerProcessLoadFn spawnerProcessLoadFn, SpawnerSpawnEntityFn spawnEntityFn, SpawnerReturnEntityFn returnEntityToSpawnerFn, SpawnerDestroyFn destroySpawnerFn)
             : _spawnerCreate(createSpawnerFn)
             , _spawnerProcessLoad(spawnerProcessLoadFn)
             , _spawnerSpawnEntity(spawnEntityFn)
             , _spawnerReturnEntity(returnEntityToSpawnerFn)
             , _spawnerDestroy(destroySpawnerFn) {}
 
-        EntityTypeFactory(EntityTypeFactory &) = delete;
+        EntityTypeFactory(EntityTypeFactory &)            = delete;
         EntityTypeFactory &operator=(EntityTypeFactory &) = delete;
 
         ~EntityTypeFactory() {
@@ -146,7 +143,7 @@ namespace MafiaMP::Game::Streaming {
         }
 
         // Update our collection of spawners
-        // Each spawner can be in one of two states: Ready or Loading. 
+        // Each spawner can be in one of two states: Ready or Loading.
         // A spawner is Ready if it has finished loading and is now ready to spawn entities. A spawner is Loading if it is still loading and not ready to spawn entities.
         void Update() {
             auto spawnerIter = _spawners.begin();
@@ -177,7 +174,7 @@ namespace MafiaMP::Game::Streaming {
                                 requestFinished = true;
 
                                 EntityTrackingInfo *trackingInfo = createdEntities.back()._info.get();
-                                trackingInfo->_entity          = entity;
+                                trackingInfo->_entity            = entity;
                                 if (trackingInfo->_requestFinish)
                                     trackingInfo->_requestFinish(trackingInfo, true);
                             }
@@ -186,7 +183,7 @@ namespace MafiaMP::Game::Streaming {
                                 requestFinished = true;
 
                                 ExtendedTrackingInfo &request = *requestIter;
-                                request._info->_entity     = nullptr;
+                                request._info->_entity        = nullptr;
                                 if (request._info->_requestFinish)
                                     request._info->_requestFinish(nullptr, false);
                             }

--- a/code/client/src/sdk/c_entity_factory.h
+++ b/code/client/src/sdk/c_entity_factory.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <utils/hooking/hook_function.h>
-#include <utils/hooking/hooking.h>
 
 #include "entities/c_entity.h"
 

--- a/code/client/src/sdk/c_game.cpp
+++ b/code/client/src/sdk/c_game.cpp
@@ -1,5 +1,4 @@
 #include "c_game.h"
-#include <utils/hooking/hooking.h>
 #include "patterns.h"
 
 namespace SDK {

--- a/code/client/src/sdk/c_game_input_module.cpp
+++ b/code/client/src/sdk/c_game_input_module.cpp
@@ -1,6 +1,5 @@
 #include "c_game_input_module.h"
 
-#include <utils/hooking/hooking.h>
 #include "patterns.h"
 
 namespace SDK {

--- a/code/client/src/sdk/c_game_traffic_module.cpp
+++ b/code/client/src/sdk/c_game_traffic_module.cpp
@@ -1,11 +1,9 @@
 #include "c_game_traffic_module.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "patterns.h"
 
 namespace SDK {
-    C_GameTrafficModule* C_GameTrafficModule::GetInstance() {
+    C_GameTrafficModule *C_GameTrafficModule::GetInstance() {
         return hook::this_call<C_GameTrafficModule *>(gPatterns.C_GameTrafficModule__GetInstance);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/c_ie.cpp
+++ b/code/client/src/sdk/c_ie.cpp
@@ -1,13 +1,12 @@
 #include "c_ie.h"
-#include <utils/hooking/hooking.h>
 #include "patterns.h"
 
 namespace SDK {
     void *C_IE::Alloc(size_t size) {
-        return hook::this_call<void *>(gPatterns.C_IE__AllocAddr, size);
+        return hook::this_call<void *>(gPatterns.C_IE__Alloc, size);
     }
 
     void C_IE::Free(void *ptr) {
-        hook::this_call<void>(gPatterns.C_IE__FreeAddr, ptr);
+        hook::this_call<void>(gPatterns.C_IE__Free, ptr);
     }
 } // namespace SDK

--- a/code/client/src/sdk/c_player_teleport_module.cpp
+++ b/code/client/src/sdk/c_player_teleport_module.cpp
@@ -1,7 +1,6 @@
 #include "c_player_teleport_module.h"
 
 #include "patterns.h"
-#include <utils/hooking/hooking.h>
 
 namespace SDK {
     C_PlayerTeleportModule *C_PlayerTeleportModule::GetInstance() {

--- a/code/client/src/sdk/c_player_teleport_module.cpp
+++ b/code/client/src/sdk/c_player_teleport_module.cpp
@@ -21,6 +21,6 @@ namespace SDK {
     }
 
     C_PlayerTeleportModule *GetPlayerTeleportModule() {
-        return hook::call<C_PlayerTeleportModule *>(hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 83 78 38 00 74 13"));
+        return hook::call<C_PlayerTeleportModule *>(gPatterns.C_PlayerTeleportModule__GetPlayerTeleportModule);
     }
 } // namespace SDK

--- a/code/client/src/sdk/c_stream_map.cpp
+++ b/code/client/src/sdk/c_stream_map.cpp
@@ -1,6 +1,5 @@
 #include "c_stream_map.h"
 
-#include <utils/hooking/hooking.h>
 #include "patterns.h"
 
 namespace SDK {
@@ -16,27 +15,27 @@ namespace SDK {
         hook::this_call(gPatterns.C_StreamMap__ClosePart, this);
     }
 
-    const char* C_StreamMap::GetGame() {
+    const char *C_StreamMap::GetGame() {
         return m_sGameName;
     }
 
-    const char* C_StreamMap::GetMission() {
+    const char *C_StreamMap::GetMission() {
         return m_sMissionName;
     }
 
-    const char* C_StreamMap::GetPart() {
+    const char *C_StreamMap::GetPart() {
         return m_sPartName;
     }
 
-    void C_StreamMap::OpenGame(const char* game) {
+    void C_StreamMap::OpenGame(const char *game) {
         hook::this_call(gPatterns.C_StreamMap__OpenGame, this, game);
     }
 
-    void C_StreamMap::OpenMission(const char* mission) {
+    void C_StreamMap::OpenMission(const char *mission) {
         hook::this_call(gPatterns.C_StreamMap__OpenMission, this, mission);
     }
 
-    void C_StreamMap::OpenPart(const char* part) {
+    void C_StreamMap::OpenPart(const char *part) {
         hook::this_call(gPatterns.C_StreamMap__OpenPart, this, part);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/c_ticked_module_manager.cpp
+++ b/code/client/src/sdk/c_ticked_module_manager.cpp
@@ -1,5 +1,4 @@
 #include "c_ticked_module_manager.h"
-#include <utils/hooking/hooking.h>
 
 #include "patterns.h"
 

--- a/code/client/src/sdk/c_time_budget_info.cpp
+++ b/code/client/src/sdk/c_time_budget_info.cpp
@@ -1,14 +1,13 @@
 #include "c_time_budget_info.h"
-#include <utils/hooking/hooking.h>
 
 #include "patterns.h"
 
 namespace SDK {
     void C_TimeBudgetInfo::C_Ctx::BeginUpdate(C_TimeBudgetInfo *pTimeBudgetInfo) {
-        hook::this_call<void>(gPatterns.C_Ctx__BeginUpdateAddr, this, pTimeBudgetInfo);
+        hook::this_call<void>(gPatterns.C_Ctx__BeginUpdate, this, pTimeBudgetInfo);
     }
 
     void C_TimeBudgetInfo::C_Ctx::EndUpdate() {
-        hook::this_call<void>(gPatterns.C_Ctx__EndUpdateAddr, this);
+        hook::this_call<void>(gPatterns.C_Ctx__EndUpdate, this);
     }
 } // namespace SDK

--- a/code/client/src/sdk/entities/c_car.cpp
+++ b/code/client/src/sdk/entities/c_car.cpp
@@ -1,8 +1,7 @@
 #include "c_car.h"
-#include "c_vehicle.h"
 #include "c_human_2.h"
+#include "c_vehicle.h"
 
-#include <utils/hooking/hooking.h>
 #include "../patterns.h"
 
 #ifdef NONSTEAM_SUPPORT
@@ -72,7 +71,7 @@ namespace SDK {
         }
     }
 
-    bool C_Car::SetSeatStatus(I_Human2 *human, unsigned int seatID, S_BaseSeat::E_BaseSeatStatus status){
+    bool C_Car::SetSeatStatus(I_Human2 *human, unsigned int seatID, S_BaseSeat::E_BaseSeatStatus status) {
         return hook::this_call<bool>(gPatterns.C_Car__SetSeatStatus, this, human, seatID, status);
     }
 
@@ -96,7 +95,7 @@ namespace SDK {
         hook::this_call<void>(gPatterns.C_Car__PosefujZimuVShopu, this, dirt);
     }
 
-    void C_Car::RestoreCar(){
+    void C_Car::RestoreCar() {
         hook::this_call<void>(gPatterns.C_Car__RestoreCar, this);
     }
 

--- a/code/client/src/sdk/entities/c_door.cpp
+++ b/code/client/src/sdk/entities/c_door.cpp
@@ -1,7 +1,5 @@
 #include "c_door.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../patterns.h"
 
 namespace SDK {
@@ -64,4 +62,4 @@ namespace SDK {
     void C_Door::DisableAction() {
         hook::this_call(gPatterns.C_Door__DisableAction, this);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/entities/c_entity.cpp
+++ b/code/client/src/sdk/entities/c_entity.cpp
@@ -1,26 +1,25 @@
 #include "c_entity.h"
 
-#include <utils/hooking/hooking.h>
 #include "../patterns.h"
 
 namespace SDK {
     void C_Entity::GameInit() {
-        hook::this_call<void>(gPatterns.C_Entity__GameInitAddr, this);
+        hook::this_call<void>(gPatterns.C_Entity__GameInit, this);
     }
 
     void C_Entity::GameDone() {
-        hook::this_call<void>(gPatterns.C_Entity__GameDoneAddr, this);
+        hook::this_call<void>(gPatterns.C_Entity__GameDone, this);
     }
 
     void C_Entity::Activate() {
-        hook::this_call<void>(gPatterns.C_Entity__ActivateAddr, this);
+        hook::this_call<void>(gPatterns.C_Entity__Activate, this);
     }
 
     void C_Entity::Deactivate() {
-        hook::this_call<void>(gPatterns.C_Entity__DeactivateAddr, this);
+        hook::this_call<void>(gPatterns.C_Entity__Deactivate, this);
     }
 
     void C_Entity::Release() {
-        hook::this_call<void>(gPatterns.C_Entity__ReleaseAddr, this);
+        hook::this_call<void>(gPatterns.C_Entity__Release, this);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/entities/c_entity_list.cpp
+++ b/code/client/src/sdk/entities/c_entity_list.cpp
@@ -1,10 +1,9 @@
 #include "c_entity_list.h"
 
-#include <utils/hooking/hooking.h>
 #include "../patterns.h"
 
 namespace SDK {
     C_EntityList *GetEntityList() {
         return hook::this_call<C_EntityList *>(gPatterns.C_EntityList__GetEntityList);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/entities/c_human2.cpp
+++ b/code/client/src/sdk/entities/c_human2.cpp
@@ -1,4 +1,3 @@
-#include <utils/hooking/hooking.h>
 #include "../patterns.h"
 
 #include "c_human_2.h"
@@ -11,4 +10,4 @@ namespace SDK {
     void C_Human2::EnableHumanClothes() {
         hook::this_call<void>(gPatterns.C_Human2__EnableHumanClothes, this);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/entities/c_vehicle.cpp
+++ b/code/client/src/sdk/entities/c_vehicle.cpp
@@ -1,7 +1,5 @@
 #include "c_vehicle.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../patterns.h"
 
 namespace SDK {
@@ -86,13 +84,11 @@ namespace SDK {
         hook::this_call(gPatterns.C_Vehicle__SetWheelTintColor, this, color);
     }
 
-    void C_Vehicle::SetInteriorColors(ue::sys::math::C_Vector4 const *color1, ue::sys::math::C_Vector4 const *color2, ue::sys::math::C_Vector4 const *color3,
-                                      ue::sys::math::C_Vector4 const *color4, ue::sys::math::C_Vector4 const *color5) {
+    void C_Vehicle::SetInteriorColors(ue::sys::math::C_Vector4 const *color1, ue::sys::math::C_Vector4 const *color2, ue::sys::math::C_Vector4 const *color3, ue::sys::math::C_Vector4 const *color4, ue::sys::math::C_Vector4 const *color5) {
         hook::this_call(gPatterns.C_Vehicle__SetInteriorColors, this, color1, color2, color3, color4, color5);
     }
 
-    void C_Vehicle::GetInteriorColors(ue::sys::math::C_Vector4 *color1, ue::sys::math::C_Vector4 *color2, ue::sys::math::C_Vector4 *color3, ue::sys::math::C_Vector4 *color4,
-                                      ue::sys::math::C_Vector4 *color5) const {
+    void C_Vehicle::GetInteriorColors(ue::sys::math::C_Vector4 *color1, ue::sys::math::C_Vector4 *color2, ue::sys::math::C_Vector4 *color3, ue::sys::math::C_Vector4 *color4, ue::sys::math::C_Vector4 *color5) const {
         *color1 = m_InteriorColors[0];
         *color2 = m_InteriorColors[1];
         *color3 = m_InteriorColors[2];
@@ -146,31 +142,28 @@ namespace SDK {
     }
 
     void C_Vehicle::EnableRadio(bool enable) {
-
         // NB: Need to shift to (I assume to a radio) interface
-        void* shiftedThis = reinterpret_cast<void *>(reinterpret_cast<uint64_t>(this) + 0x268);
+        void *shiftedThis = reinterpret_cast<void *>(reinterpret_cast<uint64_t>(this) + 0x268);
         hook::this_call(gPatterns.C_Vehicle__EnableRadio, shiftedThis, enable);
     }
 
     void C_Vehicle::TurnRadioOn(bool on) {
-
-         // NB: Need to shift to (I assume to a radio) interface
-        void* shiftedThis = reinterpret_cast<void *>(reinterpret_cast<uint64_t>(this) + 0x268);
+        // NB: Need to shift to (I assume to a radio) interface
+        void *shiftedThis = reinterpret_cast<void *>(reinterpret_cast<uint64_t>(this) + 0x268);
         hook::this_call(gPatterns.C_Vehicle__TurnRadioOn, shiftedThis, on);
     }
 
-     uint32_t C_Vehicle::GetRadioStation() {
+    uint32_t C_Vehicle::GetRadioStation() {
         constexpr uint32_t RADIO_LAST = 5;
         return m_RadioSound ? m_RadioSound->GetCurrentStation() : RADIO_LAST;
-     }
+    }
 
     void C_Vehicle::ChangeRadioStation(uint32_t stationSelection) {
-
         // NB: Internally selects radio using E_RadioStationSelection.
         // In IDA, see C_GameMusicModule::SelectStation and C_AvailableStations::GetStationById
 
         // NB: Need to shift to (I assume to a radio) interface
-        void* shiftedThis = reinterpret_cast<void *>(reinterpret_cast<uint64_t>(this) + 0x268);
+        void *shiftedThis = reinterpret_cast<void *>(reinterpret_cast<uint64_t>(this) + 0x268);
         hook::this_call(gPatterns.C_Vehicle__ChangeRadioStation, shiftedThis, stationSelection);
     }
 

--- a/code/client/src/sdk/entities/human/c_human_inventory.cpp
+++ b/code/client/src/sdk/entities/human/c_human_inventory.cpp
@@ -1,7 +1,5 @@
 #include "c_human_inventory.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../patterns.h"
 
 namespace SDK {
@@ -40,4 +38,4 @@ namespace SDK {
     void C_HumanInventory::UseMedkit() {
         hook::this_call(gPatterns.C_HumanInventory__UseMedkit, this);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/entities/human/c_human_script.cpp
+++ b/code/client/src/sdk/entities/human/c_human_script.cpp
@@ -1,7 +1,5 @@
 #include "c_human_script.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../c_game.h"
 #include "../c_human_2.h"
 

--- a/code/client/src/sdk/entities/human/c_human_weapon_controller.cpp
+++ b/code/client/src/sdk/entities/human/c_human_weapon_controller.cpp
@@ -1,7 +1,6 @@
 #include "c_human_weapon_controller.h"
 
 #include <logging/logger.h>
-#include <utils/hooking/hooking.h>
 
 #include "../../patterns.h"
 

--- a/code/client/src/sdk/entities/player/c_player_model_manager.cpp
+++ b/code/client/src/sdk/entities/player/c_player_model_manager.cpp
@@ -1,6 +1,5 @@
 #include "c_player_model_manager.h"
 
-#include <utils/hooking/hooking.h>
 #include "../../patterns.h"
 
 namespace SDK {
@@ -10,6 +9,6 @@ namespace SDK {
 
     void *C_PlayerModelManager::SwitchSpawnProfile(ue::sys::utils::C_HashName name) {
         void *pSyncObject;
-        return hook::this_call<void *>(gPatterns.C_PlayerModelManager__SwitchPlayerProfileAddr, this, &pSyncObject, name);
+        return hook::this_call<void *>(gPatterns.C_PlayerModelManager__SwitchPlayerProfile, this, &pSyncObject, name);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/inventory/c_inventory_wrapper.cpp
+++ b/code/client/src/sdk/inventory/c_inventory_wrapper.cpp
@@ -1,6 +1,5 @@
 #include "c_inventory_wrapper.h"
 
-#include <utils/hooking/hooking.h>
 #include "../patterns.h"
 
 namespace SDK {
@@ -15,4 +14,4 @@ namespace SDK {
     uint64_t C_InventoryWrapper::TellMoney() {
         return hook::this_call<uint64_t>(gPatterns.C_InventoryWrapper__TellMoney, this);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
@@ -12,9 +12,5 @@ namespace SDK {
             ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> database;
             return hook::this_call<ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> &>(gPatterns.C_MafiaDBs__GetVehiclesDatabase, this, database);
         }
-
-        C_MafiaDBs *GetMafiaDBs() {
-            return hook::call<C_MafiaDBs *>(gPatterns.C_MafiaDBs__GetMafiaDbs);
-        }
     }; // namespace mafia::framework
 };     // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
@@ -13,7 +13,7 @@ namespace SDK {
             return hook::this_call<ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> &>(gPatterns.C_MafiaDBs__GetVehiclesDatabase, this, database);
         }
 
-        static C_MafiaDBs *GetMafiaDBs() {
+        C_MafiaDBs *GetMafiaDBs() {
             return hook::call<C_MafiaDBs *>(gPatterns.C_MafiaDBs__GetMafiaDbs);
         }
     }; // namespace mafia::framework

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
@@ -4,10 +4,13 @@
 
 namespace SDK {
     namespace mafia::framework {
-
         SDK::ue::C_WeakPtr<SDK::mafia::framework::C_VehiclesDatabase> C_MafiaDBs::GetVehiclesDatabase() {
             ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> database;
-            return hook::this_call<ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> &>(gPatterns.C_MafiaDBS__GetVehiclesDatabase, this, database);
+            return hook::this_call<ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> &>(gPatterns.C_MafiaDBs__GetVehiclesDatabase, this, database);
+        }
+
+        static C_MafiaDBs *GetMafiaDBs() {
+            return hook::call<C_MafiaDBs *>(hook::get_opcode_address("E8 ? ? ? ? 48 8D 55 87 48 8B C8"));
         }
     }; // namespace mafia::framework
 };     // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
@@ -1,7 +1,5 @@
 #include "c_mafia_dbs.h"
 
-#include "../../patterns.h"
-
 namespace SDK {
     namespace mafia::framework {
         void C_MafiaDBs::GetTablesDatabase(ue::sys::sodb::C_SysODB *odb) {

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.cpp
@@ -1,16 +1,20 @@
 #include "c_mafia_dbs.h"
 
-#include "sdk/patterns.h"
+#include "../../patterns.h"
 
 namespace SDK {
     namespace mafia::framework {
+        void C_MafiaDBs::GetTablesDatabase(ue::sys::sodb::C_SysODB *odb) {
+            hook::this_call(gPatterns.C_MafiaDBs__GetTablesDatabase, this, odb);
+        }
+
         SDK::ue::C_WeakPtr<SDK::mafia::framework::C_VehiclesDatabase> C_MafiaDBs::GetVehiclesDatabase() {
             ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> database;
             return hook::this_call<ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> &>(gPatterns.C_MafiaDBs__GetVehiclesDatabase, this, database);
         }
 
         static C_MafiaDBs *GetMafiaDBs() {
-            return hook::call<C_MafiaDBs *>(hook::get_opcode_address("E8 ? ? ? ? 48 8D 55 87 48 8B C8"));
+            return hook::call<C_MafiaDBs *>(gPatterns.C_MafiaDBs__GetMafiaDbs);
         }
     }; // namespace mafia::framework
 };     // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
@@ -5,15 +5,11 @@
 #include "sdk/ue/c_weak_ptr.h"
 #include "sdk/ue/sys/sodb/c_sys_odb.h"
 
-#include "../../patterns.h"
-
 namespace SDK {
     namespace mafia::framework {
         class C_MafiaDBs {
           public:
-            void GetTablesDatabase(ue::sys::sodb::C_SysODB *odb) {
-                hook::this_call(gPatterns.C_MafiaDBs__GetTablesDatabase, this, odb);
-            }
+            void GetTablesDatabase(ue::sys::sodb::C_SysODB *);
 
             ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> GetVehiclesDatabase();
         };

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
@@ -14,6 +14,6 @@ namespace SDK {
             ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> GetVehiclesDatabase();
         };
 
-        static C_MafiaDBs *GetMafiaDBs();
+        C_MafiaDBs *GetMafiaDBs();
     }; // namespace mafia::framework
 };     // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
@@ -2,8 +2,8 @@
 
 #include "c_vehicles_database.h"
 
-#include "sdk/ue/c_weak_ptr.h"
-#include "sdk/ue/sys/sodb/c_sys_odb.h"
+#include "../../ue/c_weak_ptr.h"
+#include "../../ue/sys/sodb/c_sys_odb.h"
 
 namespace SDK {
     namespace mafia::framework {

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
@@ -5,23 +5,19 @@
 #include "sdk/ue/c_weak_ptr.h"
 #include "sdk/ue/sys/sodb/c_sys_odb.h"
 
-#include <utils/hooking/hooking.h>
+#include "../../patterns.h"
 
 namespace SDK {
     namespace mafia::framework {
         class C_MafiaDBs {
           public:
             void GetTablesDatabase(ue::sys::sodb::C_SysODB *odb) {
-                const auto pattern = hook::get_opcode_address("E8 ? ? ? ? 48 8B F8 49 8B C7");
-                hook::this_call(pattern, this, odb);
+                hook::this_call(gPatterns.C_MafiaDBs__GetTablesDatabase, this, odb);
             }
 
             ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> GetVehiclesDatabase();
         };
 
-        static C_MafiaDBs *GetMafiaDBs() {
-            const auto pattern = hook::get_opcode_address("E8 ? ? ? ? 48 8D 55 87 48 8B C8");
-            return hook::call<C_MafiaDBs *>(pattern);
-        }
+        static C_MafiaDBs *GetMafiaDBs();
     }; // namespace mafia::framework
 };     // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
+++ b/code/client/src/sdk/mafia/framework/c_mafia_dbs.h
@@ -2,6 +2,8 @@
 
 #include "c_vehicles_database.h"
 
+#include "../../patterns.h"
+
 #include "../../ue/c_weak_ptr.h"
 #include "../../ue/sys/sodb/c_sys_odb.h"
 
@@ -14,6 +16,8 @@ namespace SDK {
             ue::C_WeakPtr<mafia::framework::C_VehiclesDatabase> GetVehiclesDatabase();
         };
 
-        C_MafiaDBs *GetMafiaDBs();
+        static C_MafiaDBs *GetMafiaDBs() {
+            return hook::call<C_MafiaDBs *>(gPatterns.C_MafiaDBs__GetMafiaDBs);
+        }
     }; // namespace mafia::framework
 };     // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_mafia_framework.cpp
+++ b/code/client/src/sdk/mafia/framework/c_mafia_framework.cpp
@@ -1,6 +1,5 @@
 #include "c_mafia_framework.h"
 
-#include <utils/hooking/hooking.h>
 #include "../../patterns.h"
 
 namespace SDK {
@@ -9,4 +8,4 @@ namespace SDK {
             return *reinterpret_cast<C_MafiaFramework **>(gPatterns.C_MafiaFramework__Instance);
         }
     }; // namespace mafia::framework
-}
+} // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_vehicles_database.h
+++ b/code/client/src/sdk/mafia/framework/c_vehicles_database.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "sdk/gamedb/tables/vehicles/s_vehicles_table_item.h"
-#include "sdk/ue/sys/sodb/c_database_interface.h"
+#include "../../gamedb/tables/vehicles/s_vehicles_table_item.h"
+#include "../../ue/sys/sodb/c_database_interface.h"
 
 namespace SDK {
     namespace mafia::framework {

--- a/code/client/src/sdk/mafia/framework/c_vehicles_database.h
+++ b/code/client/src/sdk/mafia/framework/c_vehicles_database.h
@@ -5,22 +5,20 @@
 
 namespace SDK {
     namespace mafia::framework {
-
         /**
          * Contains XBin data at runtime; assume to be read-only
          */
         class C_VehiclesDatabase: public ue::sys::sodb::C_DatabaseInterface {
           public:
+            uint32_t GetVehiclesCount();
 
-              uint32_t GetVehiclesCount();
-              
-              typedef ue::sys::sodb::C_Database::C_AccessorConst<SDK::gamedb::tables::vehicles::S_VehiclesTableItem> TItemAccessorConst;
-              const TItemAccessorConst& GetVehicleByIndex(uint32_t index);
+            typedef ue::sys::sodb::C_Database::C_AccessorConst<SDK::gamedb::tables::vehicles::S_VehiclesTableItem> TItemAccessorConst;
+            const TItemAccessorConst &GetVehicleByIndex(uint32_t index);
 
-              const TItemAccessorConst &GetVehicleByID(uint32_t index);
+            const TItemAccessorConst &GetVehicleByID(uint32_t index);
 
-              // Hash as in model name converted to FNV hash
-              const TItemAccessorConst &GetVehicleByModel(uint64_t hash);
+            // Hash as in model name converted to FNV hash
+            const TItemAccessorConst &GetVehicleByModel(uint64_t hash);
         };
     }; // namespace mafia::framework
 };     // namespace SDK

--- a/code/client/src/sdk/mafia/framework/director/c_game_director.cpp
+++ b/code/client/src/sdk/mafia/framework/director/c_game_director.cpp
@@ -1,7 +1,5 @@
 #include "c_game_director.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../../patterns.h"
 
 namespace SDK {
@@ -13,5 +11,5 @@ namespace SDK {
         int64_t *C_GameDirector::GetDistrict(ue::sys::math::C_Vector const &vec) {
             return hook::this_call<int64_t *>(gPatterns.C_GameDirector__GetDistrict, this, vec);
         }
-    }
-}
+    } // namespace mafia::framework::director
+} // namespace SDK

--- a/code/client/src/sdk/mafia/framework/director/c_game_director.cpp
+++ b/code/client/src/sdk/mafia/framework/director/c_game_director.cpp
@@ -1,7 +1,5 @@
 #include "c_game_director.h"
 
-#include "../../../patterns.h"
-
 namespace SDK {
     namespace mafia::framework::director {
         C_GameDirector *C_GameDirector::GetInstance() {

--- a/code/client/src/sdk/mafia/framework/director/c_game_director.h
+++ b/code/client/src/sdk/mafia/framework/director/c_game_director.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include "../../../patterns.h"
 
 #include "../../../entities/c_entity.h"
 #include "../../../ue/sys/math/c_vector.h"
@@ -22,4 +22,4 @@ namespace SDK {
             int64_t *GetDistrict(ue::sys::math::C_Vector const &);
         };
     }; // namespace mafia::framework::director
-};    // namespace SDK
+};     // namespace SDK

--- a/code/client/src/sdk/mafia/streaming/c_actors_slot_wrapper.cpp
+++ b/code/client/src/sdk/mafia/streaming/c_actors_slot_wrapper.cpp
@@ -1,7 +1,5 @@
 #include "c_actors_slot_wrapper.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../c_ie.h"
 
 #include "../../patterns.h"
@@ -9,24 +7,23 @@
 namespace SDK {
     namespace mafia::streaming {
         C_ActorsSlotWrapper::C_ActorsSlotWrapper(E_EntityType type, unsigned int maxActorsCnt, unsigned int maxCrewCnt, char const *a5, bool allowDuplicationCaching) {
-            hook::this_call<void>(gPatterns.C_ActorsSlotWrapper__C_ActorsSlotWrapperAddr, this, type, maxActorsCnt, maxCrewCnt, a5, allowDuplicationCaching);
+            hook::this_call<void>(gPatterns.C_ActorsSlotWrapper__C_ActorsSlotWrapper, this, type, maxActorsCnt, maxCrewCnt, a5, allowDuplicationCaching);
         }
 
         void C_ActorsSlotWrapper::UpdateToCreateActors(unsigned int a2, int a3) {
-            hook::this_call<void>(gPatterns.C_ActorsSlotWrapper__UpdateToCreateActorsAddr, this, a2, a3);
+            hook::this_call<void>(gPatterns.C_ActorsSlotWrapper__UpdateToCreateActors, this, a2, a3);
         }
 
         void C_ActorsSlotWrapper::GetFreeActor(ue::C_WeakPtr<ue::sys::core::C_SceneObject> &a2, bool a3, C_Actor **a4) {
-            (*(void(__thiscall *)(C_ActorsSlotWrapper *, ue::C_WeakPtr<ue::sys::core::C_SceneObject> &, bool, C_Actor **))gPatterns.C_ActorsSlotWrapper__GetFreeActorAddr)(this, a2,
-                                                                                                                                                                           a3, a4);
+            (*(void(__thiscall *)(C_ActorsSlotWrapper *, ue::C_WeakPtr<ue::sys::core::C_SceneObject> &, bool, C_Actor **))gPatterns.C_ActorsSlotWrapper__GetFreeActor)(this, a2, a3, a4);
         }
 
         void C_ActorsSlotWrapper::ReturnActor(C_Actor *pActor) {
-            hook::this_call<void>(gPatterns.C_ActorsSlotWrapper__ReturnActorAddr, this, pActor);
+            hook::this_call<void>(gPatterns.C_ActorsSlotWrapper__ReturnActor, this, pActor);
         }
 
         void C_ActorsSlotWrapper::Close(bool destroyActorItems) {
-            hook::this_call<void>(gPatterns.C_ActorsSlotWrapper__CloseAddr, this, destroyActorItems);
+            hook::this_call<void>(gPatterns.C_ActorsSlotWrapper__Close, this, destroyActorItems);
         }
 
         void *C_ActorsSlotWrapper::operator new(size_t size) {
@@ -36,5 +33,5 @@ namespace SDK {
         void C_ActorsSlotWrapper::operator delete(void *ptr) {
             C_IE::Free(ptr);
         }
-    }
-}
+    } // namespace mafia::streaming
+} // namespace SDK

--- a/code/client/src/sdk/mafia/streaming/c_slot_wrapper.cpp
+++ b/code/client/src/sdk/mafia/streaming/c_slot_wrapper.cpp
@@ -1,13 +1,11 @@
 #include "c_slot_wrapper.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../patterns.h"
 
 namespace SDK {
     namespace mafia::streaming {
         bool C_SlotWrapper::LoadData(char const *a2, ue::sys::core::C_Scene *a3, unsigned int a4, char const *a5, bool *a6, bool a7) {
-            return hook::this_call<bool>(gPatterns.C_SlotWrapper__LoadDataAddr, this, a2, a3, a4, a5, a6, a7);
+            return hook::this_call<bool>(gPatterns.C_SlotWrapper__LoadData, this, a2, a3, a4, a5, a6, a7);
         }
     } // namespace mafia::streaming
-}
+} // namespace SDK

--- a/code/client/src/sdk/mafia/streaming/c_streaming_module.cpp
+++ b/code/client/src/sdk/mafia/streaming/c_streaming_module.cpp
@@ -1,13 +1,11 @@
 #include "c_streaming_module.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../patterns.h"
 
 namespace SDK {
     namespace mafia::streaming {
         void C_StreamingModule::SetStreamingPosSource(E_StreamingPosSource source) {
-            hook::this_call(gPatterns.C_StreamingModule__SetStreamingPosSourceAddr, this, source);
+            hook::this_call(gPatterns.C_StreamingModule__SetStreamingPosSource, this, source);
         }
     }; // namespace mafia::streaming
-}
+} // namespace SDK

--- a/code/client/src/sdk/mafia/streaming/c_streaming_module.h
+++ b/code/client/src/sdk/mafia/streaming/c_streaming_module.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "sdk/ue/c_ptr.h"
-#include "sdk/ue/c_string.h"
-#include "sdk/ue/sys/math/c_vector.h"
+#include "../../ue/c_ptr.h"
+#include "../../ue/c_string.h"
+#include "../../ue/sys/math/c_vector.h"
 
 namespace SDK {
     namespace mafia::streaming {

--- a/code/client/src/sdk/mafia/ui/c_game_gui_2_module.cpp
+++ b/code/client/src/sdk/mafia/ui/c_game_gui_2_module.cpp
@@ -1,25 +1,23 @@
 #include "c_game_gui_2_module.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../patterns.h"
 
 namespace SDK {
     namespace mafia::ui {
         void C_GameGUI2Module::SendHUDSimpleBooleanMessage(char const *str, bool unk) {
-            hook::this_call<void>(hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 49 8B 97 ? ? ? ? 4C 8D 05 ? ? ? ?"), this, str, unk);
+            hook::this_call<void>(gPatterns.C_GameGUI2Module_SendHUDSimpleBooleanMessage, this, str, unk);
         }
 
-        void C_GameGUI2Module::SendMessageMovie(char const* title, char const* msg, ue::C_Variant* varArgs, unsigned int unk2) {
-            hook::this_call(hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8D 5D 58"), this, title, msg, varArgs, unk2);
+        void C_GameGUI2Module::SendMessageMovie(char const *title, char const *msg, ue::C_Variant *varArgs, unsigned int unk2) {
+            hook::this_call(gPatterns.C_GameGUI2Module_SendMessageMovie, this, title, msg, varArgs, unk2);
         }
 
         C_GameGUI2Module *C_GameGUI2Module::GetInstance() {
-            return *reinterpret_cast<C_GameGUI2Module **>(gPatterns.C_GameGUI2Module_Instance);
+            return *reinterpret_cast<C_GameGUI2Module **>(gPatterns.C_GameGUI2Module_GetInstance);
         }
 
         C_GameGUI2Module *GetGameGui2Module() {
             return hook::call<C_GameGUI2Module *>(hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 40 80 F6 01"));
         }
     } // namespace mafia::ui
-}
+} // namespace SDK

--- a/code/client/src/sdk/mafia/ui/c_game_gui_2_module.cpp
+++ b/code/client/src/sdk/mafia/ui/c_game_gui_2_module.cpp
@@ -13,7 +13,7 @@ namespace SDK {
         }
 
         C_GameGUI2Module *C_GameGUI2Module::GetInstance() {
-            return *reinterpret_cast<C_GameGUI2Module **>(gPatterns.C_GameGUI2Module__GetInstance);
+            return *reinterpret_cast<C_GameGUI2Module **>(gPatterns.C_GameGUI2Module__Instance);
         }
 
         C_GameGUI2Module *GetGameGui2Module() {

--- a/code/client/src/sdk/mafia/ui/c_game_gui_2_module.cpp
+++ b/code/client/src/sdk/mafia/ui/c_game_gui_2_module.cpp
@@ -5,19 +5,19 @@
 namespace SDK {
     namespace mafia::ui {
         void C_GameGUI2Module::SendHUDSimpleBooleanMessage(char const *str, bool unk) {
-            hook::this_call<void>(gPatterns.C_GameGUI2Module_SendHUDSimpleBooleanMessage, this, str, unk);
+            hook::this_call<void>(gPatterns.C_GameGUI2Module__SendHUDSimpleBooleanMessage, this, str, unk);
         }
 
         void C_GameGUI2Module::SendMessageMovie(char const *title, char const *msg, ue::C_Variant *varArgs, unsigned int unk2) {
-            hook::this_call(gPatterns.C_GameGUI2Module_SendMessageMovie, this, title, msg, varArgs, unk2);
+            hook::this_call(gPatterns.C_GameGUI2Module__SendMessageMovie, this, title, msg, varArgs, unk2);
         }
 
         C_GameGUI2Module *C_GameGUI2Module::GetInstance() {
-            return *reinterpret_cast<C_GameGUI2Module **>(gPatterns.C_GameGUI2Module_GetInstance);
+            return *reinterpret_cast<C_GameGUI2Module **>(gPatterns.C_GameGUI2Module__GetInstance);
         }
 
         C_GameGUI2Module *GetGameGui2Module() {
-            return hook::call<C_GameGUI2Module *>(hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 40 80 F6 01"));
+            return hook::call<C_GameGUI2Module *>(gPatterns.C_GameGUI2Module__GetGameGui2Module);
         }
     } // namespace mafia::ui
 } // namespace SDK

--- a/code/client/src/sdk/mafia/ui/menu/c_save_menu.cpp
+++ b/code/client/src/sdk/mafia/ui/menu/c_save_menu.cpp
@@ -1,14 +1,11 @@
 #include "c_save_menu.h"
 
-#include <utils/hooking/hooking.h>
 #include "../../../patterns.h"
 
 namespace SDK {
     namespace mafia::ui::menu {
         void C_MenuSave::OpenDebugLoadChapterString(ue::C_String &savePath, bool unk) {
-            const auto C_MenuSave__OpenDebugLoadChapterStringAddr =
-                reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ? 48 81 EC ? ? ? ? 4C 8B F9 4C 8B F2").get_first());
-            hook::this_call(C_MenuSave__OpenDebugLoadChapterStringAddr, this, &savePath, unk);
+            hook::this_call(gPatterns.C_MenuSave__OpenDebugLoadChapterString, this, &savePath, unk);
         }
     } // namespace mafia::ui::menu
 } // namespace SDK

--- a/code/client/src/sdk/mafia/ui/navigation/c_navigation.cpp
+++ b/code/client/src/sdk/mafia/ui/navigation/c_navigation.cpp
@@ -1,7 +1,5 @@
 #include "c_navigation.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../../patterns.h"
 
 namespace SDK {
@@ -10,7 +8,7 @@ namespace SDK {
             return hook::this_call<mafia::ui::navigation::C_Navigation *>(gPatterns.C_Navigation__GetInstance);
         }
 
-        void C_Navigation::EnableGPSCustomPath(std::vector<ue::sys::math::C_Vector> const& vectors) {
+        void C_Navigation::EnableGPSCustomPath(std::vector<ue::sys::math::C_Vector> const &vectors) {
             hook::this_call(gPatterns.C_Navigation__EnableGPSCustomPath, this, vectors);
         }
 
@@ -54,12 +52,12 @@ namespace SDK {
             return hook::this_call<bool>(gPatterns.C_Navigation__UnregisterId, this, id);
         }
 
-        bool C_Navigation::UnregisterHuman(I_Human2* human, bool unk) {
+        bool C_Navigation::UnregisterHuman(I_Human2 *human, bool unk) {
             return hook::this_call<bool>(gPatterns.C_Navigation__UnregisterHuman, this, human, unk);
         }
 
         bool C_Navigation::UnregisterVehicle(C_Actor *ent) {
             return hook::this_call<bool>(gPatterns.C_Navigation__UnregisterVehicle, this, ent);
         }
-    }
-}
+    } // namespace mafia::ui::navigation
+} // namespace SDK

--- a/code/client/src/sdk/mafia/ui/support/c_fader.cpp
+++ b/code/client/src/sdk/mafia/ui/support/c_fader.cpp
@@ -1,7 +1,5 @@
 #include "c_fader.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../../patterns.h"
 
 namespace SDK {
@@ -16,4 +14,4 @@ namespace SDK {
     void mafia::ui::support::C_Fader::Reset() {
         hook::this_call(gPatterns.C_Fader__Reset, this);
     }
-}
+} // namespace SDK

--- a/code/client/src/sdk/patterns.cpp
+++ b/code/client/src/sdk/patterns.cpp
@@ -238,7 +238,7 @@ namespace SDK {
         gPatterns.C_InventoryWrapper__TellMoney = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 28 48 8B 41 68 80 78 18 09"));
 
         // C_MafiaDBs
-        gPatterns.C_MafiaDBs__GetMafiaDbs         = hook::get_opcode_address("E8 ? ? ? ? 48 8D 55 87 48 8B C8");
+        gPatterns.C_MafiaDBs__GetMafiaDBs         = hook::get_opcode_address("E8 ? ? ? ? 48 8D 55 87 48 8B C8");
         gPatterns.C_MafiaDBs__GetTablesDatabase   = hook::get_opcode_address("E8 ? ? ? ? 48 8B F8 49 8B C7");
         gPatterns.C_MafiaDBs__GetVehiclesDatabase = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 48 8B DA 41 B8 06 00 00 00"));
 

--- a/code/client/src/sdk/patterns.cpp
+++ b/code/client/src/sdk/patterns.cpp
@@ -143,12 +143,13 @@ namespace SDK {
         gPatterns.C_GameFramework__IsSuspended = reinterpret_cast<uint64_t>(hook::get_pattern("80 39 ? 74 ? 80 79 ? ?"));
 
         // C_GameGUI2Module
-        uint64_t C_GameGUI2Module              = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
-        uint8_t *C_GameGUI2Module_Bytes        = reinterpret_cast<uint8_t *>(C_GameGUI2Module);
-        gPatterns.C_GameGUI2Module_GetInstance = reinterpret_cast<uint64_t>(C_GameGUI2Module_Bytes + *(int32_t *)(C_GameGUI2Module_Bytes + 3) + 7);
+        uint64_t C_GameGUI2Module               = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
+        uint8_t *C_GameGUI2Module_Bytes         = reinterpret_cast<uint8_t *>(C_GameGUI2Module);
+        gPatterns.C_GameGUI2Module__GetInstance = reinterpret_cast<uint64_t>(C_GameGUI2Module_Bytes + *(int32_t *)(C_GameGUI2Module_Bytes + 3) + 7);
 
-        gPatterns.C_GameGUI2Module_SendHUDSimpleBooleanMessage = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 49 8B 97 ? ? ? ? 4C 8D 05 ? ? ? ?");
-        gPatterns.C_GameGUI2Module_SendMessageMovie            = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8D 5D 58");
+        gPatterns.C_GameGUI2Module__GetGameGui2Module           = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 40 80 F6 01");
+        gPatterns.C_GameGUI2Module__SendHUDSimpleBooleanMessage = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 49 8B 97 ? ? ? ? 4C 8D 05 ? ? ? ?");
+        gPatterns.C_GameGUI2Module__SendMessageMovie            = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8D 5D 58");
 
         // C_GameInputModule
         gPatterns.C_GameInputModule__GetGameInputModule = hook::get_opcode_address("E8 ? ? ? ? 4C 8B F0 8B D7");
@@ -237,6 +238,7 @@ namespace SDK {
         gPatterns.C_InventoryWrapper__TellMoney = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 28 48 8B 41 68 80 78 18 09"));
 
         // C_MafiaDBs
+        gPatterns.C_MafiaDBs__GetMafiaDbs         = hook::get_opcode_address("E8 ? ? ? ? 48 8D 55 87 48 8B C8");
         gPatterns.C_MafiaDBs__GetTablesDatabase   = hook::get_opcode_address("E8 ? ? ? ? 48 8B F8 49 8B C7");
         gPatterns.C_MafiaDBs__GetVehiclesDatabase = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 48 8B DA 41 B8 06 00 00 00"));
 
@@ -285,11 +287,12 @@ namespace SDK {
         gPatterns.C_PlayerModelManager__SwitchPlayerProfile = hook::get_opcode_address("E8 ? ? ? ? 48 8B C3 48 83 C4 20 5B C3 48 8B 41 48");
 
         // C_PlayerTeleportModule
-        uint64_t C_PlayerTeleportModule            = hook::get_opcode_address("E8 ? ? ? ? 83 78 38 00 74 13") + 0xD;
-        uint8_t *C_PlayerTeleportModule_Bytes      = reinterpret_cast<uint8_t *>(C_PlayerTeleportModule);
-        gPatterns.C_PlayerTeleportModule__Instance = reinterpret_cast<uint64_t>(C_PlayerTeleportModule_Bytes + *(int32_t *)(C_PlayerTeleportModule_Bytes + 3) + 7);
+        uint64_t C_PlayerTeleportModule       = hook::get_opcode_address("E8 ? ? ? ? 83 78 38 00 74 13") + 0xD;
+        uint8_t *C_PlayerTeleportModule_Bytes = reinterpret_cast<uint8_t *>(C_PlayerTeleportModule);
 
-        gPatterns.C_PlayerTeleportModule__TeleportPlayer = reinterpret_cast<uint64_t>(hook::get_pattern("40 56 48 83 EC 50 83 79 38 00"));
+        gPatterns.C_PlayerTeleportModule__GetPlayerTeleportModule = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 83 78 38 00 74 13");
+        gPatterns.C_PlayerTeleportModule__Instance                = reinterpret_cast<uint64_t>(C_PlayerTeleportModule_Bytes + *(int32_t *)(C_PlayerTeleportModule_Bytes + 3) + 7);
+        gPatterns.C_PlayerTeleportModule__TeleportPlayer          = reinterpret_cast<uint64_t>(hook::get_pattern("40 56 48 83 EC 50 83 79 38 00"));
 
         // C_ProfileSpawner
         gPatterns.C_ProfileSpawner__C_ProfileSpawner      = hook::get_opcode_address("49 8B CE E8 ? ? ? ? 48 8B 5C 24 ? 48 8D 05 ? ? ? ?", 3);

--- a/code/client/src/sdk/patterns.cpp
+++ b/code/client/src/sdk/patterns.cpp
@@ -143,11 +143,11 @@ namespace SDK {
         gPatterns.C_GameFramework__IsSuspended = reinterpret_cast<uint64_t>(hook::get_pattern("80 39 ? 74 ? 80 79 ? ?"));
 
         // C_GameGUI2Module
-        uint64_t C_GameGUI2Module            = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
-        uint8_t *C_GameGUI2Module_Bytes      = reinterpret_cast<uint8_t *>(C_GameGUI2Module);
-        gPatterns.C_GameGUI2Module__Instance = reinterpret_cast<uint64_t>(C_GameGUI2Module_Bytes + *(int32_t *)(C_GameGUI2Module_Bytes + 3) + 7);
+        uint64_t C_GameGUI2Module       = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
+        uint8_t *C_GameGUI2Module_Bytes = reinterpret_cast<uint8_t *>(C_GameGUI2Module);
 
         gPatterns.C_GameGUI2Module__GetGameGui2Module           = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 40 80 F6 01");
+        gPatterns.C_GameGUI2Module__Instance                    = reinterpret_cast<uint64_t>(C_GameGUI2Module_Bytes + *(int32_t *)(C_GameGUI2Module_Bytes + 3) + 7);
         gPatterns.C_GameGUI2Module__SendHUDSimpleBooleanMessage = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 49 8B 97 ? ? ? ? 4C 8D 05 ? ? ? ?");
         gPatterns.C_GameGUI2Module__SendMessageMovie            = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8D 5D 58");
 
@@ -159,8 +159,9 @@ namespace SDK {
         gPatterns.C_GameTrafficModule__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 80 7E 07 00");
 
         // C_GfxEnvironmentEffects
-        uint64_t C_GfxEnvironmentEffects            = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 05 ? ? ? ? 48 8B 40 28 48 8B 40 28"));
-        uint8_t *C_GfxEnvironmentEffects_Bytes      = reinterpret_cast<uint8_t *>(C_GfxEnvironmentEffects);
+        uint64_t C_GfxEnvironmentEffects       = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 05 ? ? ? ? 48 8B 40 28 48 8B 40 28"));
+        uint8_t *C_GfxEnvironmentEffects_Bytes = reinterpret_cast<uint8_t *>(C_GfxEnvironmentEffects);
+
         gPatterns.C_GfxEnvironmentEffects__Instance = reinterpret_cast<uint64_t>(C_GfxEnvironmentEffects_Bytes + *(int32_t *)(C_GfxEnvironmentEffects_Bytes + 3) + 7);
 
         // C_HashName
@@ -244,8 +245,9 @@ namespace SDK {
 
         // C_MafiaFramework
         // NOTE: extract address from another function and its instruction
-        uint64_t C_MafiaFramework            = hook::get_opcode_address("E8 ? ? ? ? E8 ? ? ? ? 48 8B C8 48 8B 10 FF 92 ? ? ? ? 33 D2 48 8B C8") + 0xD;
-        uint8_t *C_MafiaFramework_Bytes      = reinterpret_cast<uint8_t *>(C_MafiaFramework);
+        uint64_t C_MafiaFramework       = hook::get_opcode_address("E8 ? ? ? ? E8 ? ? ? ? 48 8B C8 48 8B 10 FF 92 ? ? ? ? 33 D2 48 8B C8") + 0xD;
+        uint8_t *C_MafiaFramework_Bytes = reinterpret_cast<uint8_t *>(C_MafiaFramework);
+
         gPatterns.C_MafiaFramework__Instance = reinterpret_cast<uint64_t>(C_MafiaFramework_Bytes + *(int32_t *)(C_MafiaFramework_Bytes + 3) + 7);
 
         // C_Matrix

--- a/code/client/src/sdk/patterns.cpp
+++ b/code/client/src/sdk/patterns.cpp
@@ -4,169 +4,34 @@ namespace SDK {
     Patterns gPatterns;
 
     void Patterns::InitPatterns() {
-        gPatterns.C_Entity__GameInit   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 8B 49 ? 8B C1 C1 E8 ? A8 ?"));
-        gPatterns.C_Entity__GameDone   = reinterpret_cast<uint64_t>(hook::get_pattern("40 57 48 83 EC ? 8B 41 ? 48 8B F9 25 ? ? ? ?"));
-        gPatterns.C_Entity__Activate   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 8B 49 ? 8B C1 25 ? ? ? ?"));
-        gPatterns.C_Entity__Deactivate = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 8B 41 ? 48 8B D9 25 ? ? ? ? 3D ? ? ? ?"));
-        gPatterns.C_Entity__Release    = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 8B 41 ? 48 8B D9 25 ? ? ? ?"));
-
-        gPatterns.C_GameAudioModule__GetAudioModule = hook::get_opcode_address("E8 ? ? ? ? 48 8B C8 8D 53 51");
-        gPatterns.C_GameAudioModule__SetCutsceneVolume = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 8B 81 ? ? ? ? 89 90 ? ? ? ?");
-        gPatterns.C_GameAudioModule__SetDialogueVolume = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 20 49 8B F0 48 8B F9");
-        gPatterns.C_GameAudioModule__SetMasterVolume   = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 8B 49 20 E9 ? ? ? ?");
-        gPatterns.C_GameAudioModule__SetMusicVolume    = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 89 5C 24 ? 57 48 83 EC 70 48 8B 59 70");
-        gPatterns.C_GameAudioModule__SetSfxVolume      = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 8B C4 48 81 EC ? ? ? ? F3 0F 10 15 ? ? ? ? 0F 57 C0");
-        gPatterns.C_GameAudioModule__SetDynamicRange   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 8B DA 89 91 ? ? ? ? E8 ? ? ? ?"));
-
-        gPatterns.C_Game__GetGame = hook::get_opcode_address("E8 ? ? ? ? 0F B7 5B 20");
-
-        gPatterns.C_GameInputModule__GetGameInputModule = hook::get_opcode_address("E8 ? ? ? ? 4C 8B F0 8B D7");
-        gPatterns.C_GameInputModule__PauseInput         = hook::get_opcode_address("E8 ? ? ? ? 48 8B 43 08 C6 80 ? ? ? ? ? 48 8B 5C 24 ?");
-
-        gPatterns.C_EntityList__GetEntityList = hook::get_opcode_address("E8 ? ? ? ? 8B 53 40 48 8B C8");
-
-        gPatterns.C_EntityFactory__ComputeHash    = reinterpret_cast<uint64_t>(hook::get_pattern("0F B6 11 33 C0 84 D2 74 2C"));
-        gPatterns.C_EntityFactory__CreateEntity   = hook::get_opcode_address("E8 ? ? ? ? 48 89 46 10 48 8B 4E 10");
-        gPatterns.C_EntityFactory__RegisterEntity = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 58 4C 8B C1"));
-
-        gPatterns.C_PlayerModelManager__IsPlayerLoaded      = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 49 28 48 85 C9 75 03"));
-        gPatterns.C_PlayerModelManager__SwitchPlayerProfile = hook::get_opcode_address("E8 ? ? ? ? 48 8B C3 48 83 C4 20 5B C3 48 8B 41 48");
-
+        // C_ActorsSlotWrapper
         gPatterns.C_ActorsSlotWrapper__C_ActorsSlotWrapper  = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 6C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC ? 48 8B 74 24 ? 48 8D 05 ? ? ? ? 33 ED"));
-        gPatterns.C_ActorsSlotWrapper__UpdateToCreateActors = hook::get_opcode_address("E8 ? ? ? ? EB 25 83 FF 0A");
+        gPatterns.C_ActorsSlotWrapper__Close                = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 55 48 83 EC ? C7 41 ? ? ? ? ?"));
         gPatterns.C_ActorsSlotWrapper__GetFreeActor         = reinterpret_cast<uint64_t>(hook::pattern("41 56 48 83 EC ? 33 C0 48 8B F9").get_first(-0xA));
         gPatterns.C_ActorsSlotWrapper__ReturnActor          = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 56 48 83 EC ? 48 8B 41 ? 40 32 ED"));
-        gPatterns.C_ActorsSlotWrapper__Close                = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 55 48 83 EC ? C7 41 ? ? ? ? ?"));
+        gPatterns.C_ActorsSlotWrapper__UpdateToCreateActors = hook::get_opcode_address("E8 ? ? ? ? EB 25 83 FF 0A");
 
-        gPatterns.C_SlotWrapper__LoadData = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B 41 ? 41 8B F9 49 8B F0 48 8B EA"));
-
-        gPatterns.C_StreamingModule__SetStreamingPosSource = reinterpret_cast<uint64_t>(hook::get_pattern("33 C0 89 91 ? ? ? ? 48 89 81 ? ? ? ?"));
-
-        gPatterns.C_HumanSpawner__C_HumanSpawnerVtbl          = hook::get_opcode_address("49 8B CE E8 ? ? ? ? 48 8B 5C 24 ? 48 8D 05 ? ? ? ?", 15);
-        gPatterns.C_HumanSpawner__SetupDefaultArchetypeObject = reinterpret_cast<uint64_t>(hook::get_pattern("4C 8B DC 49 89 5B ? 56 57 41 56 48 83 EC ? 48 8B 1D ? ? ? ?"));
-
-        gPatterns.C_ProfileSpawner__C_ProfileSpawner      = hook::get_opcode_address("49 8B CE E8 ? ? ? ? 48 8B 5C 24 ? 48 8D 05 ? ? ? ?", 3);
-        gPatterns.C_ProfileSpawner__C_ProfileSpawnerDctor = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 56 57 48 83 EC ? 48 8D 05 ? ? ? ? 48 8B D9"));
-        gPatterns.C_ProfileSpawner__IsSpawnProfileLoaded  = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 E8 ? ? ? ? 48 8B C8 48 8D 54 24 ? E8 ? ? ? ? 4C 8D 83 ? ? ? ?"));
-        gPatterns.C_ProfileSpawner__CreateActor           = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? BA ? ? ? ? 48 89 4B 08");
-        gPatterns.C_ProfileSpawner__ReturnObject          = hook::get_opcode_address("E8 ? ? ? ? EB 6F 48 8B 5F 08");
-
-        gPatterns.C_GameCamera__GetInstanceInternal = hook::get_opcode_address("E8 ? ? ? ? 48 8B C8 4C 8D 4D 30");
-
-        gPatterns.C_WeatherManager2__GetDayTimeHours = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? F3 0F 10 81 ? ? ? ?"));
-        gPatterns.C_WeatherManager2__GetDayTimeRel   = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? 48 8B 41 ?"));
-        gPatterns.C_WeatherManager2__SetDayTimeHours = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 59 0D ? ? ? ? 0F 57 DB F3 0F 10 15 ? ? ? ? 0F 28 C1 F3 0F 5C C2 0F 2F C3 73 ? 0F 28 D1 F3 0F 10 0D ? ? ? ? 0F 28 C1 F3 "
-                                                                                                    "0F 5C C2 0F 2F C3 72 ? F3 0F 11 89 ? ? ? ? C3 F3 0F 11 91 ? ? ? ? C3 ? ? ? ? ? ? ? ? F3 0F 59 0D ? ? ? ?"));
-        gPatterns.C_WeatherManager2__SetDayTimeRel   = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 59 0D ? ? ? ? F3 0F 11 49 ? C3 ? ? F3 0F 59 0D ? ? ? ? 0F 57 DB"));
-        gPatterns.C_WeatherManager2__SetWeatherSet   = hook::get_opcode_address("E8 ? ? ? ? 48 8D 4F ? E8 ? ? ? ? E9 ? ? ? ? E8 ? ? ? ?");
-
-        gPatterns.I_Core__GetInstance         = hook::get_opcode_address("E8 ? ? ? ? 4C 8B 40 68");
-        gPatterns.C_SceneObject__SetTransform = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8D 41 ? 48 8B D9 0F 10 02"));
-
-        gPatterns.renameme__SpawnObject  = hook::get_opcode_address("E8 ? ? ? ? 33 F6 EB 9F");
-        gPatterns.renameme__SpawnObject2 = hook::get_opcode_address("E8 ? ? ? ? 49 8B 4C 3F ?");
-        gPatterns.renameme__SpawnObject3 = hook::get_opcode_address("E8 ? ? ? ? 4C 8B E8 49 8B CD");
-
-        gPatterns.I_VirtualFileSystemCache__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 41 0F B7 CF");
-
-        gPatterns.I_GameDirector__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 48 8B 57 18 84 DB");
-        gPatterns.C_GameDirector__GetDistrict = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 50 F2 0F 10 02"));
-
-        //NOTE: extract address from another function and its instruction
-        uint64_t C_MafiaFramework            = hook::get_opcode_address("E8 ? ? ? ? E8 ? ? ? ? 48 8B C8 48 8B 10 FF 92 ? ? ? ? 33 D2 48 8B C8") + 0xD;
-        uint8_t *C_MafiaFramework_Bytes      = reinterpret_cast<uint8_t *>(C_MafiaFramework);
-        gPatterns.C_MafiaFramework__Instance = reinterpret_cast<uint64_t>(C_MafiaFramework_Bytes + *(int32_t *)(C_MafiaFramework_Bytes + 3) + 7);
-
-        uint64_t C_PlayerTeleportModule            = hook::get_opcode_address("E8 ? ? ? ? 83 78 38 00 74 13") + 0xD;
-        uint8_t *C_PlayerTeleportModule_Bytes      = reinterpret_cast<uint8_t *>(C_PlayerTeleportModule);
-        gPatterns.C_PlayerTeleportModule__Instance = reinterpret_cast<uint64_t>(C_PlayerTeleportModule_Bytes + *(int32_t *)(C_PlayerTeleportModule_Bytes + 3) + 7);
-
-        gPatterns.C_PlayerTeleportModule__TeleportPlayer = reinterpret_cast<uint64_t>(hook::get_pattern("40 56 48 83 EC 50 83 79 38 00"));
-
-        uint64_t C_GfxEnvironmentEffects           = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 05 ? ? ? ? 48 8B 40 28 48 8B 40 28"));
-        uint8_t *C_GfxEnvironmentEffects_Bytes     = reinterpret_cast<uint8_t *>(C_GfxEnvironmentEffects);
-        gPatterns.C_GfxEnvironmentEffects_Instance = reinterpret_cast<uint64_t>(C_GfxEnvironmentEffects_Bytes + *(int32_t *)(C_GfxEnvironmentEffects_Bytes + 3) + 7);
-
-        // C_GameGui2Module
-        uint64_t C_GameGui2Module              = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
-        uint8_t *C_GameGui2Module_Bytes        = reinterpret_cast<uint8_t *>(C_GameGui2Module);
-        gPatterns.C_GameGUI2Module_GetInstance = reinterpret_cast<uint64_t>(C_GameGui2Module_Bytes + *(int32_t *)(C_GameGui2Module_Bytes + 3) + 7);
-
-        gPatterns.C_GameGUI2Module_SendHUDSimpleBooleanMessage = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 49 8B 97 ? ? ? ? 4C 8D 05 ? ? ? ?");
-        gPatterns.C_GameGUI2Module_SendMessageMovie            = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8D 5D 58");
-
-        // C_Matrix
-        gPatterns.C_Matrix__SetDir2     = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F2 0F 10 02 48 8B D9 8B 42 ?"));
-        gPatterns.C_Matrix__SetDir      = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 40 53 48 83 EC ? 48 8B D9 48 8D 4C 24 ?"));
-        gPatterns.C_Matrix__SetDir3     = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F3 0F 10 02 0F 57 DB"));
-        gPatterns.C_Matrix__SetRot      = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ?"));
-        gPatterns.C_Matrix__SetRotEuler = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 0F 10 02"));
-
-        gPatterns.C_HashName__ComputeHash = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 74 24 ? 41 56 48 83 EC ? 4C 8B F2 48 8B F1 48 85 C9"));
-        gPatterns.C_HashName__SetName     = reinterpret_cast<uint64_t>(hook::get_pattern("44 0F B6 11 4C 8B C2"));
-
-        gPatterns.C_String__SetString = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B FA 48 8B F1 48 85 D2 75 ? 48 8B 09"));
-
-        gPatterns.C_IE__Alloc = hook::get_opcode_address("48 ? ? 48 ? ? ? ? B9 04 14 00 00 E8 ? ? ? ? 48", 0xD);
-        gPatterns.C_IE__Free  = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 41 B8 0D 00 00 00 48 ? ? ? ? ? ? 48");
-
-        gPatterns.C_TickedModuleManager__GetTickedModuleManager = hook::get_opcode_address("E8 ? ? ? ? 45 8B 46 24");
-
-        gPatterns.C_Ctx__BeginUpdate = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 48 89 51 ? 48 8D 4C 24 ?"));
-        gPatterns.C_Ctx__EndUpdate   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 83 79 ? ? 48 8B D9 74 ? 48 8D 4C 24 ? E8 ? ? ? ? 48 8D 4C 24 ?"));
-
-        gPatterns.C_CharacterController__ActivateHandler                           = hook::get_opcode_address("E8 ? ? ? ? 48 8D 56 74");
-        gPatterns.C_CharacterController__DeactivateHandler_FromPlayerInput         = hook::get_opcode_address("E8 ? ? ? ? EB 0F 48 8B 93 ? ? ? ?");
-        gPatterns.C_CharacterStateHandlerBaseLocomotion__Idle2MoveTransitionActive = hook::get_opcode_address("E8 ? ? ? ? 48 89 75 E0 C7 45 ? ? ? ? ?");
-        gPatterns.C_CharacterStateHandlerBaseLocomotion__AddRemoveSprintDescriptor = hook::get_opcode_address("E8 ? ? ? ? 48 8B 43 08 45 33 FF");
-        gPatterns.C_CharacterStateHandlerMove__SharpTurnTransitionActive           = hook::get_opcode_address("E8 ? ? ? ? 84 C0 74 60 40 84 FF");
-        gPatterns.C_WAnimPlaybackManager__PlayState                                = hook::get_opcode_address("E8 ? ? ? ? 4C 39 7F 50");
-        gPatterns.C_BehaviorCharacter__SetWAnimVariable_float                      = hook::get_opcode_address("E9 ? ? ? ? 83 FA 20");
-        gPatterns.C_CharacterController__TriggerActorActionById                    = hook::get_opcode_address("E8 ? ? ? ? 45 0F 2F 87 ? ? ? ?");
-        gPatterns.C_CharacterStateHandlerAim__SwappingWeapon                       = hook::get_opcode_address("E8 ? ? ? ? 84 C0 75 82");
-        gPatterns.C_CharacterStateHandlerAim__UpdateAimAnimation                   = hook::get_opcode_address("E8 ? ? ? ? F3 0F 10 43 ? 48 8D 55 07");
-
-        // C_HumanScript
-        gPatterns.C_HumanScript__GetOnVehicle   = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 48 8B 5C 24 ? 48 85 C9 74 ? 83 69 ? ? 75 ? 48 8B 01 FF 50 ? 48 8B 06");
-        gPatterns.C_HumanScript__GetOffVehicle  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 48 85 C9 74 ? 83 69 ? ? 75 ? 48 8B 01 FF 50 ? 48 8B 8B ? ? ? ? 4C 8D 05 ? ? ? ?");
-        gPatterns.C_HumanScript__SetHealth      = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC ? 48 8B 09 0F 29 74 24 ?"));
-        gPatterns.C_HumanScript__ScrAim         = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 55 56 57 48 8B EC 48 83 EC 20 48 8B DA 48 8B F9 48 8B 0D ? ? ? ? 48 8D 55 20 41 0F B6 F0"));
-        gPatterns.C_HumanScript__ScrAimAt       = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 55 57 41 56 48 8B EC 48 83 EC 30 48 8B DA"));
-        gPatterns.C_HumanScript__ScrAttack      = reinterpret_cast<uint64_t>(hook::get_pattern("48 85 D2 0F 84 ? ? ? ? 55 56 41 56"));
-        gPatterns.C_HumanScript__SetStealthMove = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC 60 48 8B F9 0F B6 DA"));
-
-        // C_Quat
-        gPatterns.C_Quat__SetDir = hook::get_opcode_address("E8 ? ? ? ? F3 44 0F 59 5D ?");
+        // C_BehaviorCharacter
+        gPatterns.C_BehaviorCharacter__SetWAnimVariable_float = hook::get_opcode_address("E9 ? ? ? ? 83 FA 20");
 
         // C_Car
-        gPatterns.C_Car__Lock   = hook::get_opcode_address("E8 ? ? ? ? 33 C0 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? B8 ? ? ? ? C3");
-        gPatterns.C_Car__Unlock = hook::get_opcode_address("E8 ? ? ? ? C6 43 ? ? 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? ? C2 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? C2 ? ?");
-
-        gPatterns.C_Car__LockEntryPoints   = hook::get_opcode_address("E8 ? ? ? ? 45 8D 7E ? 48 8B 4F ?");
-        gPatterns.C_Car__UnlockEntryPoints = hook::get_opcode_address("E8 ? ? ? ? 48 8B 6C 24 ? 48 83 C4 ? 5E C3 ? ? ? ? ? ? ? ? ? 48 89 5C 24 ?");
+        gPatterns.C_Car__CloseHood       = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC ? 48 8B 81 ? ? ? ? 33 DB 48 2B 81 ? ? ? ? 33 FF 48 C1 F8 ? 48 8B F1 4C 63 F0 85 C0 0F 8E ? ? ? "
+                                                                                              "? 48 89 6C 24 ? 0F 29 74 24 ? 0F 57 F6 66 66 0F 1F 84 00 ? ? ? ? 48 8B 86 ? ? ? ? 48 63 0C B8 48 8B 86 ? ? ? ? 48 8B 14 C8 33 C9 8B 42 ? 39 05 ? ? ? ? "
+                                                                                              "48 0F 45 CA 48 85 C9 74 ? 48 0F BF 49 ? 48 8B 86 ? ? ? ? 48 8B 14 C8 0F 2F 72 ? 73 ? 0F B6 86 ? ? ? ? 48 8D 8E ? ? ? ? C0 E8 ? 45 33 C0"));
+        gPatterns.C_Car__CloseTrunk      = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4F ? 4C 8D 47 ? BA ? ? ? ? E8 ? ? ? ? 84 C0 0F 84 ? ? ? ?");
+        gPatterns.C_Car__ExplodeCar      = hook::get_opcode_address("E8 ? ? ? ? 48 8B 86 ? ? ? ? 45 33 E4 48 2B 86 ? ? ? ?");
+        gPatterns.C_Car__ExplodeCar_2    = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 11 4C 24 ? 4C 8B DC 55"));
+        gPatterns.C_Car__GetDamage       = hook::get_opcode_address("E8 ? ? ? ? 0F 57 C9 0F 2E C1 75 ? 0F 28 C1");
+        gPatterns.C_Car__GetMotorDamage  = hook::get_opcode_address("E8 ? ? ? ? 49 8B CE 0F 28 F8 E8 ? ? ? ? 0F 28 F0");
+        gPatterns.C_Car__Lock            = hook::get_opcode_address("E8 ? ? ? ? 33 C0 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? B8 ? ? ? ? C3");
+        gPatterns.C_Car__LockEntryPoints = hook::get_opcode_address("E8 ? ? ? ? 45 8D 7E ? 48 8B 4F ?");
 
         //NOTE: new version only
 #ifndef NONSTEAM_SUPPORT
         gPatterns.C_Car__OpenHood = hook::get_opcode_address("E8 ? ? ? ? 33 C0 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? 40 53 48 83 EC ? 45 33 C0 33 D2 48 8B D9 E8 ? ? ? ? 48 8B 43 ? C7 40 ? ? ? ? "
                                                              "? C7 00 ? ? ? ? 48 83 C0 ? 48 89 43 ? B8 ? ? ? ? 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? 48 83 EC ?");
 #endif
-
-        gPatterns.C_Car__CloseHood = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC ? 48 8B 81 ? ? ? ? 33 DB 48 2B 81 ? ? ? ? 33 FF 48 C1 F8 ? 48 8B F1 4C 63 F0 85 C0 0F 8E ? ? ? "
-                                                                                  "? 48 89 6C 24 ? 0F 29 74 24 ? 0F 57 F6 66 66 0F 1F 84 00 ? ? ? ? 48 8B 86 ? ? ? ? 48 63 0C B8 48 8B 86 ? ? ? ? 48 8B 14 C8 33 C9 8B 42 ? 39 05 ? ? ? ? "
-                                                                                  "48 0F 45 CA 48 85 C9 74 ? 48 0F BF 49 ? 48 8B 86 ? ? ? ? 48 8B 14 C8 0F 2F 72 ? 73 ? 0F B6 86 ? ? ? ? 48 8D 8E ? ? ? ? C0 E8 ? 45 33 C0"));
-
-        gPatterns.C_Car__OpenTrunk  = hook::get_opcode_address("E8 ? ? ? ? 4D 85 F6 74 ? 49 8D 9E ? ? ? ?");
-        gPatterns.C_Car__CloseTrunk = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4F ? 4C 8D 47 ? BA ? ? ? ? E8 ? ? ? ? 84 C0 0F 84 ? ? ? ?");
-
-        gPatterns.C_Car__SetMotorDamage = hook::get_opcode_address("E8 ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 49 21 86 ? ? ? ?");
-        gPatterns.C_Car__GetMotorDamage = hook::get_opcode_address("E8 ? ? ? ? 49 8B CE 0F 28 F8 E8 ? ? ? ? 0F 28 F0");
-
-        gPatterns.C_Car__GetDamage       = hook::get_opcode_address("E8 ? ? ? ? 0F 57 C9 0F 2E C1 75 ? 0F 28 C1");
-        gPatterns.C_Car__SetTransparency = hook::get_opcode_address("E8 ? ? ? ? 4C 39 2D ? ? ? ?");
-        gPatterns.C_Car__SetSpeed        = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 33 C0 48 83 C4 ? 5F C3 ? ? 48 83 EC ? 48 8B C2");
-        gPatterns.C_Car__SetSeatStatus   = hook::get_opcode_address("E8 ? ? ? ? 45 85 F6 8B C5");
-        gPatterns.C_Car__ExplodeCar      = hook::get_opcode_address("E8 ? ? ? ? 48 8B 86 ? ? ? ? 45 33 E4 48 2B 86 ? ? ? ?");
-        gPatterns.C_Car__ExplodeCar_2    = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 11 4C 24 ? 4C 8B DC 55"));
+        gPatterns.C_Car__OpenTrunk = hook::get_opcode_address("E8 ? ? ? ? 4D 85 F6 74 ? 49 8D 9E ? ? ? ?");
 
 #ifndef NONSTEAM_SUPPORT
         gPatterns.C_Car__PosefujZimuVShopu = hook::get_opcode_address("E8 ? ? ? ? 33 C0 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? 4C 8B 41 ?");
@@ -182,79 +47,131 @@ namespace SDK {
         gPatterns.C_Car__RestoreCar = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4B 10 0F 57 C9");
 #endif
 
-        // C_Motor
-#ifndef NONSTEAM_SUPPORT
-        gPatterns.C_Motor__SetFuel = hook::get_opcode_address("E8 ? ? ? ? 33 C0 0F 28 74 24 ? 48 83 C4 ? 5B C3 ? ? ? 48 89 5C 24 ?");
-#else
-        gPatterns.C_Motor__SetFuel = hook::get_opcode_address("E8 ? ? ? ? 41 0F 10 96 ? ? ? ?");
-#endif
+        gPatterns.C_Car__SetMotorDamage    = hook::get_opcode_address("E8 ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 49 21 86 ? ? ? ?");
+        gPatterns.C_Car__SetSeatStatus     = hook::get_opcode_address("E8 ? ? ? ? 45 85 F6 8B C5");
+        gPatterns.C_Car__SetSpeed          = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 33 C0 48 83 C4 ? 5F C3 ? ? 48 83 EC ? 48 8B C2");
+        gPatterns.C_Car__SetTransparency   = hook::get_opcode_address("E8 ? ? ? ? 4C 39 2D ? ? ? ?");
+        gPatterns.C_Car__Unlock            = hook::get_opcode_address("E8 ? ? ? ? C6 43 ? ? 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? ? C2 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? C2 ? ?");
+        gPatterns.C_Car__UnlockEntryPoints = hook::get_opcode_address("E8 ? ? ? ? 48 8B 6C 24 ? 48 83 C4 ? 5E C3 ? ? ? ? ? ? ? ? ? 48 89 5C 24 ?");
 
-        // C_Vehicle
-        gPatterns.C_Vehicle__AddVehicleFlags   = hook::get_opcode_address("E8 ? ? ? ? 40 F6 C7 08 74 0D");
-        gPatterns.C_Vehicle__ClearVehicleFlags = hook::get_opcode_address("E8 ? ? ? ? 40 80 FE 04");
-        gPatterns.C_Vehicle__SetVehicleMatrix  = hook::get_opcode_address("E8 ? ? ? ? 80 BD ? ? ? ? ? 74 0B");
-        gPatterns.C_Vehicle__SetSPZText        = hook::get_opcode_address("E8 ? ? ? ? 48 8D 5D ? BF ? ? ? ? 0F B7 13");
-        gPatterns.C_Vehicle__GetSPZText        = hook::get_opcode_address("E8 ? ? ? ? 49 8D 4F ? 48 8B D0");
-        gPatterns.C_Vehicle__SetActive         = hook::get_opcode_address("E8 ? ? ? ? F3 0F 59 35 ? ? ? ? 48 8D 8B ? ? ? ?");
+        // C_CharacterController
+        gPatterns.C_CharacterController__ActivateHandler                   = hook::get_opcode_address("E8 ? ? ? ? 48 8D 56 74");
+        gPatterns.C_CharacterController__DeactivateHandler_FromPlayerInput = hook::get_opcode_address("E8 ? ? ? ? EB 0F 48 8B 93 ? ? ? ?");
+        gPatterns.C_CharacterController__TriggerActorActionById            = hook::get_opcode_address("E8 ? ? ? ? 45 0F 2F 87 ? ? ? ?");
 
-        //NOTE: new version only
-#ifndef NONSTEAM_SUPPORT
-        gPatterns.C_Vehicle__Damage = hook::get_opcode_address("E8 ? ? ? ? 33 C0 48 8B 5C 24 ? 48 83 C4 ? 5F C3 ? ? ? ? ? ? B8 ? ? ? ?");
-#else
-        // TODO
-#endif
+        // C_CharacterStateHandlerAim
+        gPatterns.C_CharacterStateHandlerAim__SwappingWeapon     = hook::get_opcode_address("E8 ? ? ? ? 84 C0 75 82");
+        gPatterns.C_CharacterStateHandlerAim__UpdateAimAnimation = hook::get_opcode_address("E8 ? ? ? ? F3 0F 10 43 ? 48 8D 55 07");
 
-        gPatterns.C_Vehicle__SetBeaconLightsOn  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 7C 24 ? 48 83 C4 ? 5B C3 48 8B D9");
-        gPatterns.C_Vehicle__EnableRadio        = hook::get_opcode_address("E8 ? ? ? ? 49 8B 84 24 ? ? ? ? 49 8B F7");
-        gPatterns.C_Vehicle__SetBrake           = hook::get_opcode_address("E8 ? ? ? ? C7 87 ? ? ? ? ? ? ? ? 83 A7 ? ? ? ? ?");
-        gPatterns.C_Vehicle__SetEngineOn        = hook::get_opcode_address("E8 ? ? ? ? 48 8B 9E ? ? ? ? 0F B6 C3");
-        gPatterns.C_Vehicle__SetGear            = hook::get_opcode_address("E8 ? ? ? ? C6 83 ? ? ? ? ? 80 7F ? ? 74 ? 33 D2");
-        gPatterns.C_Vehicle__SetHandbrake       = hook::get_opcode_address("E8 ? ? ? ? 49 8B 86 ? ? ? ? 4D 89 BE ? ? ? ?");
-        gPatterns.C_Vehicle__SetPower           = hook::get_opcode_address("E8 ? ? ? ? F3 0F 10 8B ? ? ? ? 45 33 C0 48 8B CF E8 ? ? ? ?");
-        gPatterns.C_Vehicle__SetSearchLightsOn  = hook::get_opcode_address("E8 ? ? ? ? 80 7E ? ? 0F 84 ? ? ? ? E8 ? ? ? ?");
-        gPatterns.C_Vehicle__SetSiren           = hook::get_opcode_address("E8 ? ? ? ? 33 D2 48 8B CE E8 ? ? ? ? 48 8B 0D ? ? ? ?");
-        gPatterns.C_Vehicle__SetSpeedLimit      = hook::get_opcode_address("E8 ? ? ? ? 48 8B 8B ? ? ? ? 48 85 C9 74 ? 48 8B 89 ? ? ? ?");
-        gPatterns.C_Vehicle__SetSteer           = hook::get_opcode_address("E8 ? ? ? ? 45 33 C9 44 89 A7 ? ? ? ?");
-        gPatterns.C_Vehicle__SetHorn            = hook::get_opcode_address("E8 ? ? ? ? 48 8B 0D ? ? ? ? 48 8B 01 FF 50 ? 8B F0");
-        gPatterns.C_Vehicle__TurnRadioOn        = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 B9 ? ? ? ? ? 44 0F B6 CA"));
-        gPatterns.C_Vehicle__ChangeRadioStation = reinterpret_cast<uint64_t>(hook::get_pattern("40 57 48 83 EC 20 48 83 B9 90 12 00 00 00"));
-        gPatterns.C_Vehicle__DamageBreaks       = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B 01 48 8B D9 0F 29 7C 24 ? 0F 28 F9 FF 50 ? 84 C0 74 ? 48 8B 5B ? 4C 8D 44 24 ? 0F 29 74 24 ? 48 8D 54 "
-                                                                                                     "24 ? 0F 57 F6 C7 44 24 ? ? ? ? ? C7 44 24 ? ? ? ? ? 48 8D 8B ? ? ? ? E8 ? ? ? ? F3 0F 10 0D ? ? ? ? 0F 28 C7 F3 0F 5C C1 0F "
-                                                                                                     "2F C6 73 ? 0F 28 CF 0F 28 C1 0F 57 05 ? ? ? ? 0F 2F C6 73 ? 0F 28 F1 F3 0F 59 35 ? ? ? ? 48 8D 8B ? ? ? ? F3 0F 10 54 24 ?"));
-        gPatterns.C_Vehicle__SetDoorFree        = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 33 C0 48 8B 74 24 ? 48 83 C4 ? 5F C3 ? ? ? 40 53 48 83 EC ? 45 33 C0 33 D2 48 8B D9 E8 ? ? ? ? 48 8B 43 ? C7 40 ? ? "
-                                                                                  "? ? ? C7 00 ? ? ? ? 48 83 C0 ? 48 89 43 ? B8 ? ? ? ? 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? B8 ? ? ? ?");
-        gPatterns.C_Vehicle__SetSpeed           = hook::get_opcode_address("E8 ? ? ? ? 49 8B CF E8 ? ? ? ? 45 0F 57 C9");
-        gPatterns.C_Vehicle__SetAngularSpeed    = hook::get_opcode_address(" E8 ? ? ? ? E9 ? ? ? ? 80 BD ? ? ? ? ? 0F 85 ? ? ? ?");
-        gPatterns.C_Vehicle__IsActive           = hook::get_opcode_address("E8 ? ? ? ? 84 C0 75 0A B2 01");
-        gPatterns.C_Vehicle__IsSiren            = hook::get_opcode_address("E8 ? ? ? ? 0F B6 4D BF");
-        gPatterns.C_Vehicle__SetVehicleDirty    = hook::get_opcode_address("E9 ? ? ? ? ? ? ? ? ? ? ? ? ? ? 40 57 48 83 EC ? 48 8B 81 ? ? ? ?");
-        gPatterns.C_Vehicle__SetVehicleRust     = hook::get_opcode_address("E9 ? ? ? ? ? ? ? ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 56");
-        gPatterns.C_Vehicle__SetVehicleColor    = hook::get_opcode_address("E8 ? ? ? ? 8B 43 ? 89 87 ? ? ? ? 8B 43 ? 89 87 ? ? ? ? 83 7B ? ?");
-        gPatterns.C_Vehicle__SetInteriorColors  = hook::get_opcode_address("E8 ? ? ? ? 48 81 C4 ? ? ? ? 41 5E 41 5D 5D C3 ? ? ? ? ? ? ? ? ? ? 40 55");
-        gPatterns.C_Vehicle__SetWindowTintColor = hook::get_opcode_address("E8 ? ? ? ? 89 AE ? ? ? ? 4C 8D 9C 24 ? ? ? ?");
-        gPatterns.C_Vehicle__SetWheelTintColor  = hook::get_opcode_address("E8 ? ? ? ? 45 89 B7 ? ? ? ? 41 89 B7 ? ? ? ?");
+        // C_CharacterStateHandlerBaseLocomotion
+        gPatterns.C_CharacterStateHandlerBaseLocomotion__Idle2MoveTransitionActive = hook::get_opcode_address("E8 ? ? ? ? 48 89 75 E0 C7 45 ? ? ? ? ?");
+        gPatterns.C_CharacterStateHandlerBaseLocomotion__AddRemoveSprintDescriptor = hook::get_opcode_address("E8 ? ? ? ? 48 8B 43 08 45 33 FF");
+
+        // C_CharacterStateHandlerMove
+        gPatterns.C_CharacterStateHandlerMove__SharpTurnTransitionActive = hook::get_opcode_address("E8 ? ? ? ? 84 C0 74 60 40 84 FF");
+
+        // C_CommandLine
+        gPatterns.C_CommandLine__FindCommand = hook::get_opcode_address("E8 ? ? ? ? 40 88 7D BB");
+
+        // C_Ctx
+        gPatterns.C_Ctx__BeginUpdate = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 48 89 51 ? 48 8D 4C 24 ?"));
+        gPatterns.C_Ctx__EndUpdate   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 83 79 ? ? 48 8B D9 74 ? 48 8D 4C 24 ? E8 ? ? ? ? 48 8D 4C 24 ?"));
+
+        // C_DatabaseSystem
+        gPatterns.C_DatabaseSystem__GetDatabase =
+            reinterpret_cast<uint64_t>(hook::get_pattern("4C 8B 51 08 4D 8B C2 49 8B 42 08 80 78 19 00 75 1B 4C 8B 0A 4C 39 48 20 73 06 48 8B 40 10 EB 06 4C 8B C0 48 8B 00 80 78 19 00 74 E8 4D 3B C2 74 09 49 8B 40 20 48 39 02 73 03 4D 8B C2 4D 3B C2 74 05"));
 
         // C_Door
-        gPatterns.C_Door__Lock          = reinterpret_cast<uint64_t>(hook::get_pattern("F6 81 ? ? ? ? ? 48 8B D1 75 ? 83 B9 ? ? ? ? ? 74 ? 8B 89 ? ? ? ? 85 C9"));
         gPatterns.C_Door__AILock        = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F6 81 ? ? ? ? ? 48 8B D9 75 ? 83 B9 ? ? ? ? ? 74 ? E8 ? ? ? ? 48 8B C8 41 B0 ? 48 8B D3 E8 ? ? ? ? 83 8B ? ? ? ? ?"));
-        gPatterns.C_Door__Unlock        = hook::get_opcode_address("E8 ? ? ? ? EB ? 83 F8 ? 75 ? 48 8B 83 ? ? ? ?");
         gPatterns.C_Door__AIUnlock      = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F6 81 ? ? ? ? ? 48 8B D9 75 ? 83 B9 ? ? ? ? ? 74 ? E8 ? ? ? ? 48 8B C8 41 B0 ? 48 8B D3 E8 ? ? ? ? 83 A3 ? ? ? ? ?"));
+        gPatterns.C_Door__Close         = hook::get_opcode_address("E8 ? ? ? ? C6 86 ? ? ? ? ? 33 D2");
+        gPatterns.C_Door__DisableAction = reinterpret_cast<uint64_t>(hook::get_pattern("83 A1 ? ? ? ? ? 48 8B 81 ? ? ? ? 48 85 C0"));
+        gPatterns.C_Door__EnableAction  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 33 C0 48 83 C4 ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? 48 83 EC ?");
+        gPatterns.C_Door__Kick          = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 48 8B 42 ? 8B 48 ?");
+        gPatterns.C_Door__Lock          = reinterpret_cast<uint64_t>(hook::get_pattern("F6 81 ? ? ? ? ? 48 8B D1 75 ? 83 B9 ? ? ? ? ? 74 ? 8B 89 ? ? ? ? 85 C9"));
+        gPatterns.C_Door__Open          = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 83 B9 ? ? ? ? ? 0F 85 ? ? ? ?");
         gPatterns.C_Door__StartLockpick = reinterpret_cast<uint64_t>(hook::get_pattern("F6 81 ? ? ? ? ? 75 ? 83 B9 ? ? ? ? ? 74 ? 48 81 C1 ? ? ? ? E9 ? ? ? ?"));
         gPatterns.C_Door__StopLockpick  = reinterpret_cast<uint64_t>(hook::get_pattern("F6 81 ? ? ? ? ? 75 ? 83 B9 ? ? ? ? ? 74 ? 83 B9 ? ? ? ? ? 75 ? 45 33 C0"));
-        gPatterns.C_Door__Kick          = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 48 8B 42 ? 8B 48 ?");
-        gPatterns.C_Door__Open          = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 83 B9 ? ? ? ? ? 0F 85 ? ? ? ?");
-        gPatterns.C_Door__Close         = hook::get_opcode_address("E8 ? ? ? ? C6 86 ? ? ? ? ? 33 D2");
         gPatterns.C_Door__ToggleOpen    = hook::get_opcode_address("E8 ? ? ? ? EB ? 80 7A ? ? 74 ?");
-        gPatterns.C_Door__EnableAction  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 33 C0 48 83 C4 ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? 48 83 EC ?");
-        gPatterns.C_Door__DisableAction = reinterpret_cast<uint64_t>(hook::get_pattern("83 A1 ? ? ? ? ? 48 8B 81 ? ? ? ? 48 85 C0"));
+        gPatterns.C_Door__Unlock        = hook::get_opcode_address("E8 ? ? ? ? EB ? 83 F8 ? 75 ? 48 8B 83 ? ? ? ?");
+
+        // C_Entity
+        gPatterns.C_Entity__Activate   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 8B 49 ? 8B C1 25 ? ? ? ?"));
+        gPatterns.C_Entity__Deactivate = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 8B 41 ? 48 8B D9 25 ? ? ? ? 3D ? ? ? ?"));
+        gPatterns.C_Entity__GameDone   = reinterpret_cast<uint64_t>(hook::get_pattern("40 57 48 83 EC ? 8B 41 ? 48 8B F9 25 ? ? ? ?"));
+        gPatterns.C_Entity__GameInit   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 8B 49 ? 8B C1 C1 E8 ? A8 ?"));
+        gPatterns.C_Entity__Release    = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 8B 41 ? 48 8B D9 25 ? ? ? ?"));
+
+        // C_EntityFactory
+        gPatterns.C_EntityFactory__ComputeHash    = reinterpret_cast<uint64_t>(hook::get_pattern("0F B6 11 33 C0 84 D2 74 2C"));
+        gPatterns.C_EntityFactory__CreateEntity   = hook::get_opcode_address("E8 ? ? ? ? 48 89 46 10 48 8B 4E 10");
+        gPatterns.C_EntityFactory__RegisterEntity = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 58 4C 8B C1"));
+
+        // C_EntityList
+        gPatterns.C_EntityList__GetEntityList = hook::get_opcode_address("E8 ? ? ? ? 8B 53 40 48 8B C8");
+
+        // C_Explosion
+        gPatterns.C_Explosion__Clear = hook::get_opcode_address("E8 ? ? ? ? 66 03 DD 75 E5");
+
+        // C_Fader
+        gPatterns.C_Fader__FadeIn  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4D 67 48 8B 9C 24 ? ? ? ?");
+        gPatterns.C_Fader__FadeOut = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 0F 28 74 24 ? 48 85 C9 74 1E");
+        gPatterns.C_Fader__Reset   = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 38 80 B9 ? ? ? ? ? 74 34"));
+
+        // C_Fire
+        gPatterns.C_Fire__Clear = hook::get_opcode_address("E8 ? ? ? ? 66 03 DD 75 E7");
+
+        // C_Game
+        gPatterns.C_Game__GetGame = hook::get_opcode_address("E8 ? ? ? ? 0F B7 5B 20");
+
+        // C_GameAudioModule
+        gPatterns.C_GameAudioModule__GetAudioModule    = hook::get_opcode_address("E8 ? ? ? ? 48 8B C8 8D 53 51");
+        gPatterns.C_GameAudioModule__SetCutsceneVolume = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 8B 81 ? ? ? ? 89 90 ? ? ? ?");
+        gPatterns.C_GameAudioModule__SetDialogueVolume = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 20 49 8B F0 48 8B F9");
+        gPatterns.C_GameAudioModule__SetDynamicRange   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 8B DA 89 91 ? ? ? ? E8 ? ? ? ?"));
+        gPatterns.C_GameAudioModule__SetMasterVolume   = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 8B 49 20 E9 ? ? ? ?");
+        gPatterns.C_GameAudioModule__SetMusicVolume    = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 89 5C 24 ? 57 48 83 EC 70 48 8B 59 70");
+        gPatterns.C_GameAudioModule__SetSfxVolume      = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 8B C4 48 81 EC ? ? ? ? F3 0F 10 15 ? ? ? ? 0F 57 C0");
+
+        // C_GameCamera
+        gPatterns.C_GameCamera__GetInstanceInternal = hook::get_opcode_address("E8 ? ? ? ? 48 8B C8 4C 8D 4D 30");
+
+        // C_GameDirector
+        gPatterns.C_GameDirector__GetDistrict = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 50 F2 0F 10 02"));
+
+        // C_GameFramework
+        gPatterns.C_GameFramework__IsSuspended = reinterpret_cast<uint64_t>(hook::get_pattern("80 39 ? 74 ? 80 79 ? ?"));
+
+        // C_GameGUI2Module
+        uint64_t C_GameGUI2Module              = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
+        uint8_t *C_GameGUI2Module_Bytes        = reinterpret_cast<uint8_t *>(C_GameGUI2Module);
+        gPatterns.C_GameGUI2Module_GetInstance = reinterpret_cast<uint64_t>(C_GameGUI2Module_Bytes + *(int32_t *)(C_GameGUI2Module_Bytes + 3) + 7);
+
+        gPatterns.C_GameGUI2Module_SendHUDSimpleBooleanMessage = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 49 8B 97 ? ? ? ? 4C 8D 05 ? ? ? ?");
+        gPatterns.C_GameGUI2Module_SendMessageMovie            = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8D 5D 58");
+
+        // C_GameInputModule
+        gPatterns.C_GameInputModule__GetGameInputModule = hook::get_opcode_address("E8 ? ? ? ? 4C 8B F0 8B D7");
+        gPatterns.C_GameInputModule__PauseInput         = hook::get_opcode_address("E8 ? ? ? ? 48 8B 43 08 C6 80 ? ? ? ? ? 48 8B 5C 24 ?");
+
+        // C_GameTrafficModule
+        gPatterns.C_GameTrafficModule__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 80 7E 07 00");
+
+        // C_GfxEnvironmentEffects
+        uint64_t C_GfxEnvironmentEffects           = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 05 ? ? ? ? 48 8B 40 28 48 8B 40 28"));
+        uint8_t *C_GfxEnvironmentEffects_Bytes     = reinterpret_cast<uint8_t *>(C_GfxEnvironmentEffects);
+        gPatterns.C_GfxEnvironmentEffects_Instance = reinterpret_cast<uint64_t>(C_GfxEnvironmentEffects_Bytes + *(int32_t *)(C_GfxEnvironmentEffects_Bytes + 3) + 7);
+
+        // C_HashName
+        gPatterns.C_HashName__ComputeHash = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 74 24 ? 41 56 48 83 EC ? 4C 8B F2 48 8B F1 48 85 C9"));
+        gPatterns.C_HashName__SetName     = reinterpret_cast<uint64_t>(hook::get_pattern("44 0F B6 11 4C 8B C2"));
+
+        // C_Human2
+        gPatterns.C_Human2__EnableHumanClothes = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 8B 7C 24 ? 48 83 C4 40 41 5E C3 CC CC 48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54");
+        gPatterns.C_Human2__EnableShadows      = hook::get_opcode_address("E8 ? ? ? ? 80 7F 18 09 75 56");
 
         // C_Human2CarWrapper
         gPatterns.C_Human2CarWrapper__GetSeatID = hook::get_opcode_address("E8 ? ? ? ? 3D ? ? ? ? 75 0E");
-
-        // C_InventoryWrapper
-        gPatterns.C_InventoryWrapper__AddMoney  = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 48 8B 41 68 48 8B DA 80 78 18 09 75 4E"));
-        gPatterns.C_InventoryWrapper__AddWeapon = hook::get_opcode_address("E8 ? ? ? ? 41 38 76 4C 74 0C");
-        gPatterns.C_InventoryWrapper__TellMoney = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 28 48 8B 41 68 80 78 18 09"));
 
         // C_HumanInventory
         gPatterns.C_HumanInventory__AddItem                       = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 41 8B D6");
@@ -281,77 +198,122 @@ namespace SDK {
         gPatterns.C_HumanInventory__TellMedkit                    = hook::get_opcode_address("E8 ? ? ? ? 3B C7 7D 0C");
         gPatterns.C_HumanInventory__UseMedkit                     = hook::get_opcode_address("E8 ? ? ? ? 0F B6 D8 84 C0 74 28");
 
+        // C_HumanScript
+        gPatterns.C_HumanScript__GetOffVehicle  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 48 85 C9 74 ? 83 69 ? ? 75 ? 48 8B 01 FF 50 ? 48 8B 8B ? ? ? ? 4C 8D 05 ? ? ? ?");
+        gPatterns.C_HumanScript__GetOnVehicle   = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 48 8B 5C 24 ? 48 85 C9 74 ? 83 69 ? ? 75 ? 48 8B 01 FF 50 ? 48 8B 06");
+        gPatterns.C_HumanScript__ScrAim         = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 55 56 57 48 8B EC 48 83 EC 20 48 8B DA 48 8B F9 48 8B 0D ? ? ? ? 48 8D 55 20 41 0F B6 F0"));
+        gPatterns.C_HumanScript__ScrAimAt       = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 55 57 41 56 48 8B EC 48 83 EC 30 48 8B DA"));
+        gPatterns.C_HumanScript__ScrAttack      = reinterpret_cast<uint64_t>(hook::get_pattern("48 85 D2 0F 84 ? ? ? ? 55 56 41 56"));
+        gPatterns.C_HumanScript__SetHealth      = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC ? 48 8B 09 0F 29 74 24 ?"));
+        gPatterns.C_HumanScript__SetStealthMove = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC 60 48 8B F9 0F B6 DA"));
+
+        // C_HumanSpawner
+        gPatterns.C_HumanSpawner__C_HumanSpawnerVtbl          = hook::get_opcode_address("49 8B CE E8 ? ? ? ? 48 8B 5C 24 ? 48 8D 05 ? ? ? ?", 15);
+        gPatterns.C_HumanSpawner__SetupDefaultArchetypeObject = reinterpret_cast<uint64_t>(hook::get_pattern("4C 8B DC 49 89 5B ? 56 57 41 56 48 83 EC ? 48 8B 1D ? ? ? ?"));
+
         // C_HumanWeaponController
+        gPatterns.C_HumanWeaponController__DoShot                     = hook::get_opcode_address("E8 ? ? ? ? 0F B6 D8 84 DB 0F 84 ? ? ? ?");
+        gPatterns.C_HumanWeaponController__DoWeaponReloadDropMagazine = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 56 57 48 83 EC 60 B8 ? ? ? ?"));
+        gPatterns.C_HumanWeaponController__DoWeaponReloadInventory    = reinterpret_cast<uint64_t>(hook::get_pattern("33 C0 44 8B C2 48 89 81 ? ? ? ?"));
+        gPatterns.C_HumanWeaponController__DoWeaponReloadShowMagazine = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4F 08 4C 8B C6 BA ? ? ? ? E8 ? ? ? ? 45 33 F6");
         gPatterns.C_HumanWeaponController__DoWeaponSelectByItemId     = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 6C 24 18 48 89 74 24 20 57 48 83 EC 40 48 8B 81 60"));
         gPatterns.C_HumanWeaponController__GetRightHandWeaponID       = hook::get_opcode_address("E8 ? ? ? ? 3B 46 78 ");
-        gPatterns.C_HumanWeaponController__IsThrownWeapon             = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 81 ? ? ? ? 8B 40 48"));
         gPatterns.C_HumanWeaponController__GetShotPosDir              = hook::get_opcode_address("E8 ? ? ? ? F2 0F 10 44 24 ? 48 8B CF");
+        gPatterns.C_HumanWeaponController__IsThrownWeapon             = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 81 ? ? ? ? 8B 40 48"));
         gPatterns.C_HumanWeaponController__ResetScatterCoef           = reinterpret_cast<uint64_t>(hook::get_pattern("40 57 48 83 EC 30 48 8B F9 0F 29 74 24 ?"));
         gPatterns.C_HumanWeaponController__SetAiming                  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 43 10 48 8B 88 ? ? ? ? C6 41 14 00");
         gPatterns.C_HumanWeaponController__SetCoverFlag               = hook::get_opcode_address("E8 ? ? ? ? 48 8D 97 ? ? ? ? 49 8B CE");
         gPatterns.C_HumanWeaponController__SetFirePressedFlag         = reinterpret_cast<uint64_t>(hook::get_pattern("84 D2 75 11 33 C0"));
         gPatterns.C_HumanWeaponController__SetStickMove               = reinterpret_cast<uint64_t>(hook::get_pattern("F2 0F 10 02 F2 0F 11 81 ? ? ? ? C3"));
         gPatterns.C_HumanWeaponController__SetZoomFlag                = hook::get_opcode_address("E8 ? ? ? ? F6 87 ? ? ? ? ? 49 8B CE");
-        gPatterns.C_HumanWeaponController__DoShot                     = hook::get_opcode_address("E8 ? ? ? ? 0F B6 D8 84 DB 0F 84 ? ? ? ?");
-        gPatterns.C_HumanWeaponController__DoWeaponReloadShowMagazine = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4F 08 4C 8B C6 BA ? ? ? ? E8 ? ? ? ? 45 33 F6");
-        gPatterns.C_HumanWeaponController__DoWeaponReloadDropMagazine = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 56 57 48 83 EC 60 B8 ? ? ? ?"));
-        gPatterns.C_HumanWeaponController__DoWeaponReloadInventory    = reinterpret_cast<uint64_t>(hook::get_pattern("33 C0 44 8B C2 48 89 81 ? ? ? ?"));
 
-        // C_Human2
-        gPatterns.C_Human2__EnableHumanClothes = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 8B 7C 24 ? 48 83 C4 40 41 5E C3 CC CC 48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54");
-        gPatterns.C_Human2__EnableShadows      = hook::get_opcode_address("E8 ? ? ? ? 80 7F 18 09 75 56");
+        // C_IE
+        gPatterns.C_IE__Alloc = hook::get_opcode_address("48 ? ? 48 ? ? ? ? B9 04 14 00 00 E8 ? ? ? ? 48", 0xD);
+        gPatterns.C_IE__Free  = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 41 B8 0D 00 00 00 48 ? ? ? ? ? ? 48");
+
+        // C_InventoryWrapper
+        gPatterns.C_InventoryWrapper__AddMoney  = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 48 8B 41 68 48 8B DA 80 78 18 09 75 4E"));
+        gPatterns.C_InventoryWrapper__AddWeapon = hook::get_opcode_address("E8 ? ? ? ? 41 38 76 4C 74 0C");
+        gPatterns.C_InventoryWrapper__TellMoney = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 28 48 8B 41 68 80 78 18 09"));
+
+        // C_MafiaDBs
+        gPatterns.C_MafiaDBs__GetTablesDatabase   = hook::get_opcode_address("E8 ? ? ? ? 48 8B F8 49 8B C7");
+        gPatterns.C_MafiaDBs__GetVehiclesDatabase = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 48 8B DA 41 B8 06 00 00 00"));
+
+        // C_MafiaFramework
+        // NOTE: extract address from another function and its instruction
+        uint64_t C_MafiaFramework            = hook::get_opcode_address("E8 ? ? ? ? E8 ? ? ? ? 48 8B C8 48 8B 10 FF 92 ? ? ? ? 33 D2 48 8B C8") + 0xD;
+        uint8_t *C_MafiaFramework_Bytes      = reinterpret_cast<uint8_t *>(C_MafiaFramework);
+        gPatterns.C_MafiaFramework__Instance = reinterpret_cast<uint64_t>(C_MafiaFramework_Bytes + *(int32_t *)(C_MafiaFramework_Bytes + 3) + 7);
+
+        // C_Matrix
+        gPatterns.C_Matrix__SetDir      = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 40 53 48 83 EC ? 48 8B D9 48 8D 4C 24 ?"));
+        gPatterns.C_Matrix__SetDir2     = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F2 0F 10 02 48 8B D9 8B 42 ?"));
+        gPatterns.C_Matrix__SetDir3     = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F3 0F 10 02 0F 57 DB"));
+        gPatterns.C_Matrix__SetRot      = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ?"));
+        gPatterns.C_Matrix__SetRotEuler = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 0F 10 02"));
+
+        // C_MenuSave
+        gPatterns.C_MenuSave__OpenDebugLoadChapterString = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ? 48 81 EC ? ? ? ? 4C 8B F9 4C 8B F2"));
+
+        // C_Motor
+#ifndef NONSTEAM_SUPPORT
+        gPatterns.C_Motor__SetFuel = hook::get_opcode_address("E8 ? ? ? ? 33 C0 0F 28 74 24 ? 48 83 C4 ? 5B C3 ? ? ? 48 89 5C 24 ?");
+#else
+        gPatterns.C_Motor__SetFuel = hook::get_opcode_address("E8 ? ? ? ? 41 0F 10 96 ? ? ? ?");
+#endif
 
         // C_Navigation
-        gPatterns.C_Navigation__GetInstance               = hook::get_opcode_address("E8 ? ? ? ? 49 8B 5E 60");
         gPatterns.C_Navigation__EnableGPSCustomPath       = hook::get_opcode_address("E8 ? ? ? ? 4D 85 F6 0F 84 ? ? ? ? 4D 2B E6");
-        gPatterns.C_Navigation__SetUserMark               = hook::get_opcode_address("E8 ? ? ? ? 48 83 C4 ? C3 ? ? ? ? ? ? ? 48 89 5C 24 ? 57 48 83 EC ? 41 8B D8");
+        gPatterns.C_Navigation__GetInstance               = hook::get_opcode_address("E8 ? ? ? ? 49 8B 5E 60");
         gPatterns.C_Navigation__RegisterHumanPlayer       = hook::get_opcode_address("E8 ? ? ? ? 48 83 C6 10 49 3B F7");
         gPatterns.C_Navigation__RegisterHumanPolice       = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 38 45 33 C9 C6 44 24 ? ?"));
         gPatterns.C_Navigation__RegisterVehicleCommon     = hook::get_opcode_address("E8 ? ? ? ? 89 87 ? ? ? ? 48 8B CF E8 ? ? ? ?");
-        gPatterns.C_Navigation__RegisterVehicleMoto       = hook::get_opcode_address("E8 ? ? ? ? 48 8B 74 24 ? 48 8B 5C 24 ? 48 83 C4 20 5F C3 8B 48 04");
         gPatterns.C_Navigation__RegisterVehicleEntity     = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 49 8B F0 48 8B DA 48 8B E9"));
+        gPatterns.C_Navigation__RegisterVehicleMoto       = hook::get_opcode_address("E8 ? ? ? ? 48 8B 74 24 ? 48 8B 5C 24 ? 48 83 C4 20 5F C3 8B 48 04");
         gPatterns.C_Navigation__RegisterVehiclePolice     = hook::get_opcode_address("E8 ? ? ? ? 48 81 8E ? ? ? ? ? ? ? ? 89 86 ? ? ? ?");
         gPatterns.C_Navigation__RegisterVehiclePoliceBoat = hook::get_opcode_address("E8 ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 48 09 87 ? ? ? ? 48 8B 5C 24 ?");
         gPatterns.C_Navigation__RegisterVehiclePoliceMoto = hook::get_opcode_address("E8 ? ? ? ? 89 86 ? ? ? ? C6 86 ? ? ? ? ? 48 8B 5C 24 ?");
         gPatterns.C_Navigation__RegisterVehicleTaxi       = hook::get_opcode_address("E8 ? ? ? ? 48 89 77 38 33 F6");
-        gPatterns.C_Navigation__UnregisterId              = hook::get_opcode_address("E8 ? ? ? ? 39 BE ? ? ? ? 75 0A");
+        gPatterns.C_Navigation__SetUserMark               = hook::get_opcode_address("E8 ? ? ? ? 48 83 C4 ? C3 ? ? ? ? ? ? ? 48 89 5C 24 ? 57 48 83 EC ? 41 8B D8");
         gPatterns.C_Navigation__UnregisterHuman           = hook::get_opcode_address("E8 ? ? ? ? 8B 05 ? ? ? ? 48 8B 7C 24 ?");
+        gPatterns.C_Navigation__UnregisterId              = hook::get_opcode_address("E8 ? ? ? ? 39 BE ? ? ? ? 75 0A");
         gPatterns.C_Navigation__UnregisterVehicle         = hook::get_opcode_address("E8 ? ? ? ? 44 38 B6 ? ? ? ? 74 1B");
 
-        // init
-        gPatterns.C_InitDone_MafiaFramework = reinterpret_cast<uint64_t>(hook::get_pattern("40 55 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 0F 57 C0"));
-        gPatterns.LoadIntro                 = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 55 56 57 48 83 EC ? 48 8B E9 B9 ? ? ? ?"));
+        // C_PlayerModelManager
+        gPatterns.C_PlayerModelManager__IsPlayerLoaded      = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 49 28 48 85 C9 75 03"));
+        gPatterns.C_PlayerModelManager__SwitchPlayerProfile = hook::get_opcode_address("E8 ? ? ? ? 48 8B C3 48 83 C4 20 5B C3 48 8B 41 48");
 
-        // C_CommandLine
-        gPatterns.C_CommandLine__FindCommand = hook::get_opcode_address("E8 ? ? ? ? 40 88 7D BB");
+        // C_PlayerTeleportModule
+        uint64_t C_PlayerTeleportModule            = hook::get_opcode_address("E8 ? ? ? ? 83 78 38 00 74 13") + 0xD;
+        uint8_t *C_PlayerTeleportModule_Bytes      = reinterpret_cast<uint8_t *>(C_PlayerTeleportModule);
+        gPatterns.C_PlayerTeleportModule__Instance = reinterpret_cast<uint64_t>(C_PlayerTeleportModule_Bytes + *(int32_t *)(C_PlayerTeleportModule_Bytes + 3) + 7);
 
-        // C_GameFramework
-        gPatterns.C_GameFramework__IsSuspended = reinterpret_cast<uint64_t>(hook::get_pattern("80 39 ? 74 ? 80 79 ? ?"));
+        gPatterns.C_PlayerTeleportModule__TeleportPlayer = reinterpret_cast<uint64_t>(hook::get_pattern("40 56 48 83 EC 50 83 79 38 00"));
 
-        // C_GameTrafficModule
-        gPatterns.C_GameTrafficModule__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 80 7E 07 00");
+        // C_ProfileSpawner
+        gPatterns.C_ProfileSpawner__C_ProfileSpawner      = hook::get_opcode_address("49 8B CE E8 ? ? ? ? 48 8B 5C 24 ? 48 8D 05 ? ? ? ?", 3);
+        gPatterns.C_ProfileSpawner__C_ProfileSpawnerDctor = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 56 57 48 83 EC ? 48 8D 05 ? ? ? ? 48 8B D9"));
+        gPatterns.C_ProfileSpawner__CreateActor           = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? BA ? ? ? ? 48 89 4B 08");
+        gPatterns.C_ProfileSpawner__IsSpawnProfileLoaded  = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 E8 ? ? ? ? 48 8B C8 48 8D 54 24 ? E8 ? ? ? ? 4C 8D 83 ? ? ? ?"));
+        gPatterns.C_ProfileSpawner__ReturnObject          = hook::get_opcode_address("E8 ? ? ? ? EB 6F 48 8B 5F 08");
 
-        // C_Fader
-        gPatterns.C_Fader__FadeIn  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4D 67 48 8B 9C 24 ? ? ? ?");
-        gPatterns.C_Fader__FadeOut = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 0F 28 74 24 ? 48 85 C9 74 1E");
-        gPatterns.C_Fader__Reset   = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 38 80 B9 ? ? ? ? ? 74 34"));
+        // C_Quat
+        gPatterns.C_Quat__SetDir = hook::get_opcode_address("E8 ? ? ? ? F3 44 0F 59 5D ?");
+
+        // C_SceneObject
+        gPatterns.C_SceneObject__SetTransform = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8D 41 ? 48 8B D9 0F 10 02"));
 
         // C_ShotManager
-        gPatterns.C_ShotManager__GetInstance     = hook::get_opcode_address("E8 ? ? ? ? 49 8B 4D 18 48 8B F8");
         gPatterns.C_ShotManager__CreateExplosion = hook::get_opcode_address("E8 ? ? ? ? C6 83 ? ? ? ? ? 48 85 F6");
         gPatterns.C_ShotManager__CreateFire      = hook::get_opcode_address("E8 ? ? ? ? 48 8D 4D 88 89 87 ? ? ? ?");
+        gPatterns.C_ShotManager__GetInstance     = hook::get_opcode_address("E8 ? ? ? ? 49 8B 4D 18 48 8B F8");
 
-        // C_Fire
-        gPatterns.C_Fire__Clear = hook::get_opcode_address("E8 ? ? ? ? 66 03 DD 75 E7");
+        // C_SlotWrapper
+        gPatterns.C_SlotWrapper__LoadData = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B 41 ? 41 8B F9 49 8B F0 48 8B EA"));
 
-        // C_Explosion
-        gPatterns.C_Explosion__Clear = hook::get_opcode_address("E8 ? ? ? ? 66 03 DD 75 E5");
-
-        // Lua
-        gPatterns.Lua__pcall      = hook::get_opcode_address("E8 ? ? ? ? 85 FF 78 2B");
-        gPatterns.Lua__loadbuffer = hook::get_opcode_address("E8 ? ? ? ? 85 C0 74 2F 48 8B 47 48");
-        gPatterns.Lua__tostring   = reinterpret_cast<uint64_t>(hook::get_pattern("4C 8B C9 81 FA ? ? ? ? 7E 37"));
-        gPatterns.Lua__isstring   = hook::get_opcode_address("E8 ? ? ? ? 85 C0 74 5E 8B D3");
+        // C_StreamingModule
+        gPatterns.C_StreamingModule__SetStreamingPosSource = reinterpret_cast<uint64_t>(hook::get_pattern("33 C0 89 91 ? ? ? ? 48 89 81 ? ? ? ?"));
 
         // C_StreamMap
         gPatterns.C_StreamMap__CloseGame = reinterpret_cast<uint64_t>(
@@ -369,6 +331,9 @@ namespace SDK {
                               "08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 48 10 48 85 C9 74 34 8B 44 24 20 48 8D 71 08 89 01 48 8D 54 24 ? 48 8B 44 24 ? 48 8B CE 48 89 06 E8 ? ? ? ? 84 C0 75 11 48 83 3E 00 74 0B 48 8B CE E8 ? ? ? ? F0 FF 00 49 8B 8E ? ? ? "
                               "? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF F0 0F C1 08 83 F9 01 75 "
                               "08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC 40 53 48 83 EC 20 44 8B 41 10 48 8D 81 ? ? ? ? 48 89 81 ? ? ? ? 32 DB 41 8D 40 FD"));
+        gPatterns.C_StreamMap__GetGame     = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 41 10 48 85 C0 48 0F 44 05 ? ? ? ? C3 48 8B 81 ? ? ? ?"));
+        gPatterns.C_StreamMap__GetMission  = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 41 18 48 85 C0 48 0F 44 05 ? ? ? ? C3 48 8B 41 20"));
+        gPatterns.C_StreamMap__GetPart     = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 41 20 48 85 C0 48 0F 44 05 ? ? ? ? C3 40 53"));
         gPatterns.C_StreamMap__OpenGame    = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 33 C0"));
         gPatterns.C_StreamMap__OpenMission = reinterpret_cast<uint64_t>(
             hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 4C 8B F1 48 C7 44 24 ? ? ? ? ? 48 8D 4C 24 ? C7 44 24 ? ? ? ? ? E8 ? ? ? ? 49 8B AE ? ? ? ? B9 ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? "
@@ -380,30 +345,102 @@ namespace SDK {
                               "CC 48 89 7C 24 ? 48 8D 78 08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 70 10 48 85 F6 74 34 8B 44 24 20 48 8D 54 24 ? 89 06 48 8D 4E 08 48 8B 44 24 ? 48 89 46 08 E8 ? ? ? ? 84 C0 75 13 48 83 7E ? ? 74 0C 48 8D 4E 08 E8 ? ? ? ? "
                               "F0 FF 00 49 8B 8E ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF "
                               "F0 0F C1 08 83 F9 01 75 08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC CC CC CC CC CC CC 48 89 5C 24 ?"));
-        gPatterns.C_StreamMap__GetGame    = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 41 10 48 85 C0 48 0F 44 05 ? ? ? ? C3 48 8B 81 ? ? ? ?"));
-        gPatterns.C_StreamMap__GetMission = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 41 18 48 85 C0 48 0F 44 05 ? ? ? ? C3 48 8B 41 20"));
-        gPatterns.C_StreamMap__GetPart    = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 41 20 48 85 C0 48 0F 44 05 ? ? ? ? C3 40 53"));
 
-        // C_DatabaseSystem
-        gPatterns.C_DatabaseSystem__GetDatabase =
-            reinterpret_cast<uint64_t>(hook::get_pattern("4C 8B 51 08 4D 8B C2 49 8B 42 08 80 78 19 00 75 1B 4C 8B 0A 4C 39 48 20 73 06 48 8B 40 10 EB 06 4C 8B C0 48 8B 00 80 78 19 00 74 E8 4D 3B C2 74 09 49 8B 40 20 48 39 02 73 03 4D 8B C2 4D 3B C2 74 05"));
-
-        // C_MafiaDBs
-        gPatterns.C_MafiaDBs__GetTablesDatabase   = hook::get_opcode_address("E8 ? ? ? ? 48 8B F8 49 8B C7");
-        gPatterns.C_MafiaDBs__GetVehiclesDatabase = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 48 8B DA 41 B8 06 00 00 00"));
+        // C_String
+        gPatterns.C_String__SetString = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B FA 48 8B F1 48 85 D2 75 ? 48 8B 09"));
 
         // C_SysODB
         gPatterns.C_SysODB__GetInstance = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 41 B8 6F 50 30 4C");
 
+        // C_TickedModuleManager
+        gPatterns.C_TickedModuleManager__GetTickedModuleManager = hook::get_opcode_address("E8 ? ? ? ? 45 8B 46 24");
+
+        // C_Vehicle
+        gPatterns.C_Vehicle__AddVehicleFlags    = hook::get_opcode_address("E8 ? ? ? ? 40 F6 C7 08 74 0D");
+        gPatterns.C_Vehicle__ChangeRadioStation = reinterpret_cast<uint64_t>(hook::get_pattern("40 57 48 83 EC 20 48 83 B9 90 12 00 00 00"));
+        gPatterns.C_Vehicle__ClearVehicleFlags  = hook::get_opcode_address("E8 ? ? ? ? 40 80 FE 04");
+
+        //NOTE: new version only
+#ifndef NONSTEAM_SUPPORT
+        gPatterns.C_Vehicle__Damage = hook::get_opcode_address("E8 ? ? ? ? 33 C0 48 8B 5C 24 ? 48 83 C4 ? 5F C3 ? ? ? ? ? ? B8 ? ? ? ?");
+#else
+        // TODO
+#endif
+
+        gPatterns.C_Vehicle__DamageBreaks       = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B 01 48 8B D9 0F 29 7C 24 ? 0F 28 F9 FF 50 ? 84 C0 74 ? 48 8B 5B ? 4C 8D 44 24 ? 0F 29 74 24 ? 48 8D 54 "
+                                                                                                     "24 ? 0F 57 F6 C7 44 24 ? ? ? ? ? C7 44 24 ? ? ? ? ? 48 8D 8B ? ? ? ? E8 ? ? ? ? F3 0F 10 0D ? ? ? ? 0F 28 C7 F3 0F 5C C1 0F "
+                                                                                                     "2F C6 73 ? 0F 28 CF 0F 28 C1 0F 57 05 ? ? ? ? 0F 2F C6 73 ? 0F 28 F1 F3 0F 59 35 ? ? ? ? 48 8D 8B ? ? ? ? F3 0F 10 54 24 ?"));
+        gPatterns.C_Vehicle__EnableRadio        = hook::get_opcode_address("E8 ? ? ? ? 49 8B 84 24 ? ? ? ? 49 8B F7");
+        gPatterns.C_Vehicle__GetSPZText         = hook::get_opcode_address("E8 ? ? ? ? 49 8D 4F ? 48 8B D0");
+        gPatterns.C_Vehicle__IsActive           = hook::get_opcode_address("E8 ? ? ? ? 84 C0 75 0A B2 01");
+        gPatterns.C_Vehicle__IsSiren            = hook::get_opcode_address("E8 ? ? ? ? 0F B6 4D BF");
+        gPatterns.C_Vehicle__SetActive          = hook::get_opcode_address("E8 ? ? ? ? F3 0F 59 35 ? ? ? ? 48 8D 8B ? ? ? ?");
+        gPatterns.C_Vehicle__SetAngularSpeed    = hook::get_opcode_address(" E8 ? ? ? ? E9 ? ? ? ? 80 BD ? ? ? ? ? 0F 85 ? ? ? ?");
+        gPatterns.C_Vehicle__SetBeaconLightsOn  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 7C 24 ? 48 83 C4 ? 5B C3 48 8B D9");
+        gPatterns.C_Vehicle__SetBrake           = hook::get_opcode_address("E8 ? ? ? ? C7 87 ? ? ? ? ? ? ? ? 83 A7 ? ? ? ? ?");
+        gPatterns.C_Vehicle__SetDoorFree        = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 33 C0 48 8B 74 24 ? 48 83 C4 ? 5F C3 ? ? ? 40 53 48 83 EC ? 45 33 C0 33 D2 48 8B D9 E8 ? ? ? ? 48 8B 43 ? C7 40 ? ? "
+                                                                                  "? ? ? C7 00 ? ? ? ? 48 83 C0 ? 48 89 43 ? B8 ? ? ? ? 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? B8 ? ? ? ?");
+        gPatterns.C_Vehicle__SetEngineOn        = hook::get_opcode_address("E8 ? ? ? ? 48 8B 9E ? ? ? ? 0F B6 C3");
+        gPatterns.C_Vehicle__SetGear            = hook::get_opcode_address("E8 ? ? ? ? C6 83 ? ? ? ? ? 80 7F ? ? 74 ? 33 D2");
+        gPatterns.C_Vehicle__SetHandbrake       = hook::get_opcode_address("E8 ? ? ? ? 49 8B 86 ? ? ? ? 4D 89 BE ? ? ? ?");
+        gPatterns.C_Vehicle__SetHorn            = hook::get_opcode_address("E8 ? ? ? ? 48 8B 0D ? ? ? ? 48 8B 01 FF 50 ? 8B F0");
+        gPatterns.C_Vehicle__SetInteriorColors  = hook::get_opcode_address("E8 ? ? ? ? 48 81 C4 ? ? ? ? 41 5E 41 5D 5D C3 ? ? ? ? ? ? ? ? ? ? 40 55");
+        gPatterns.C_Vehicle__SetPower           = hook::get_opcode_address("E8 ? ? ? ? F3 0F 10 8B ? ? ? ? 45 33 C0 48 8B CF E8 ? ? ? ?");
+        gPatterns.C_Vehicle__SetSearchLightsOn  = hook::get_opcode_address("E8 ? ? ? ? 80 7E ? ? 0F 84 ? ? ? ? E8 ? ? ? ?");
+        gPatterns.C_Vehicle__SetSiren           = hook::get_opcode_address("E8 ? ? ? ? 33 D2 48 8B CE E8 ? ? ? ? 48 8B 0D ? ? ? ?");
+        gPatterns.C_Vehicle__SetSpeed           = hook::get_opcode_address("E8 ? ? ? ? 49 8B CF E8 ? ? ? ? 45 0F 57 C9");
+        gPatterns.C_Vehicle__SetSpeedLimit      = hook::get_opcode_address("E8 ? ? ? ? 48 8B 8B ? ? ? ? 48 85 C9 74 ? 48 8B 89 ? ? ? ?");
+        gPatterns.C_Vehicle__SetSPZText         = hook::get_opcode_address("E8 ? ? ? ? 48 8D 5D ? BF ? ? ? ? 0F B7 13");
+        gPatterns.C_Vehicle__SetSteer           = hook::get_opcode_address("E8 ? ? ? ? 45 33 C9 44 89 A7 ? ? ? ?");
+        gPatterns.C_Vehicle__SetVehicleColor    = hook::get_opcode_address("E8 ? ? ? ? 8B 43 ? 89 87 ? ? ? ? 8B 43 ? 89 87 ? ? ? ? 83 7B ? ?");
+        gPatterns.C_Vehicle__SetVehicleDirty    = hook::get_opcode_address("E9 ? ? ? ? ? ? ? ? ? ? ? ? ? ? 40 57 48 83 EC ? 48 8B 81 ? ? ? ?");
+        gPatterns.C_Vehicle__SetVehicleMatrix   = hook::get_opcode_address("E8 ? ? ? ? 80 BD ? ? ? ? ? 74 0B");
+        gPatterns.C_Vehicle__SetVehicleRust     = hook::get_opcode_address("E9 ? ? ? ? ? ? ? ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 56");
+        gPatterns.C_Vehicle__SetWheelTintColor  = hook::get_opcode_address("E8 ? ? ? ? 45 89 B7 ? ? ? ? 41 89 B7 ? ? ? ?");
+        gPatterns.C_Vehicle__SetWindowTintColor = hook::get_opcode_address("E8 ? ? ? ? 89 AE ? ? ? ? 4C 8D 9C 24 ? ? ? ?");
+        gPatterns.C_Vehicle__TurnRadioOn        = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 B9 ? ? ? ? ? 44 0F B6 CA"));
+
         // C_VehiclesDatabase
-        gPatterns.C_VehiclesDatabase__GetVehiclesCount  = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8B 4D 30 8B F8");
         gPatterns.C_VehiclesDatabase__GetVehicleByID    = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B 41 30 33 FF 41 8B D8 48 8B F2 48 8B E9 39 78 18 76 79"));
         gPatterns.C_VehiclesDatabase__GetVehicleByIndex = reinterpret_cast<uint64_t>(
             hook::get_pattern("48 89 5C 24 08 48 89 74 24 10 48 89 7C 24 18 41 56 48 83 EC 20 48 8B 41 30 33 DB 41 8B F8 4C 8B F2 48 8B F1 39 58 18 76 34 0F 1F 80 00 00 00 00 8B D3 48 8B C8 E8 ? ? ? ? 33 D2 48 8B C8 4C 8B 00 41 FF 50 ? 4C 8B C0 8B 48 04 "
                               "3B F9 72 2D 48 8B 46 30 2B F9 FF C3 3B 58 18 72 D3 49 C7 06 00 00 00 00 48 8B 5C 24 30 49 8B C6 48 8B 74 24 38 48 8B 7C 24 40 48 83 C4 20 41 5E C3 49 63 10 8B C7 48 69 C0 F0 00 00 00"));
         gPatterns.C_VehiclesDatabase__GetVehicleByModel = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 48 89 7C 24 20 41 55 41 56 41 57 48 83 EC 20 48 8B 41"));
+        gPatterns.C_VehiclesDatabase__GetVehiclesCount  = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8B 4D 30 8B F8");
 
-        // C_MenuSave
-        gPatterns.C_MenuSave__OpenDebugLoadChapterString = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ? 48 81 EC ? ? ? ? 4C 8B F9 4C 8B F2"));
+        // C_WAnimPlaybackManager
+        gPatterns.C_WAnimPlaybackManager__PlayState = hook::get_opcode_address("E8 ? ? ? ? 4C 39 7F 50");
+
+        // C_WeatherManager2
+        gPatterns.C_WeatherManager2__GetDayTimeHours = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? F3 0F 10 81 ? ? ? ?"));
+        gPatterns.C_WeatherManager2__GetDayTimeRel   = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? 48 8B 41 ?"));
+        gPatterns.C_WeatherManager2__SetDayTimeHours = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 59 0D ? ? ? ? 0F 57 DB F3 0F 10 15 ? ? ? ? 0F 28 C1 F3 0F 5C C2 0F 2F C3 73 ? 0F 28 D1 F3 0F 10 0D ? ? ? ? 0F 28 C1 F3 "
+                                                                                                    "0F 5C C2 0F 2F C3 72 ? F3 0F 11 89 ? ? ? ? C3 F3 0F 11 91 ? ? ? ? C3 ? ? ? ? ? ? ? ? F3 0F 59 0D ? ? ? ?"));
+        gPatterns.C_WeatherManager2__SetDayTimeRel   = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 59 0D ? ? ? ? F3 0F 11 49 ? C3 ? ? F3 0F 59 0D ? ? ? ? 0F 57 DB"));
+        gPatterns.C_WeatherManager2__SetWeatherSet   = hook::get_opcode_address("E8 ? ? ? ? 48 8D 4F ? E8 ? ? ? ? E9 ? ? ? ? E8 ? ? ? ?");
+
+        // I_Core
+        gPatterns.I_Core__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 4C 8B 40 68");
+
+        // I_GameDirector
+        gPatterns.I_GameDirector__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 48 8B 57 18 84 DB");
+
+        // I_VirtualFileSystemCache
+        gPatterns.I_VirtualFileSystemCache__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 41 0F B7 CF");
+
+        // Lua
+        gPatterns.Lua__isstring   = hook::get_opcode_address("E8 ? ? ? ? 85 C0 74 5E 8B D3");
+        gPatterns.Lua__loadbuffer = hook::get_opcode_address("E8 ? ? ? ? 85 C0 74 2F 48 8B 47 48");
+        gPatterns.Lua__pcall      = hook::get_opcode_address("E8 ? ? ? ? 85 FF 78 2B");
+        gPatterns.Lua__tostring   = reinterpret_cast<uint64_t>(hook::get_pattern("4C 8B C9 81 FA ? ? ? ? 7E 37"));
+
+        // init
+        gPatterns.C_InitDone_MafiaFramework = reinterpret_cast<uint64_t>(hook::get_pattern("40 55 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 0F 57 C0"));
+        gPatterns.LoadIntro                 = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 55 56 57 48 83 EC ? 48 8B E9 B9 ? ? ? ?"));
+
+        // TODO: rename me
+        gPatterns.renameme__SpawnObject  = hook::get_opcode_address("E8 ? ? ? ? 33 F6 EB 9F");
+        gPatterns.renameme__SpawnObject2 = hook::get_opcode_address("E8 ? ? ? ? 49 8B 4C 3F ?");
+        gPatterns.renameme__SpawnObject3 = hook::get_opcode_address("E8 ? ? ? ? 4C 8B E8 49 8B CD");
     }
 }; // namespace SDK

--- a/code/client/src/sdk/patterns.cpp
+++ b/code/client/src/sdk/patterns.cpp
@@ -143,9 +143,9 @@ namespace SDK {
         gPatterns.C_GameFramework__IsSuspended = reinterpret_cast<uint64_t>(hook::get_pattern("80 39 ? 74 ? 80 79 ? ?"));
 
         // C_GameGUI2Module
-        uint64_t C_GameGUI2Module               = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
-        uint8_t *C_GameGUI2Module_Bytes         = reinterpret_cast<uint8_t *>(C_GameGUI2Module);
-        gPatterns.C_GameGUI2Module__GetInstance = reinterpret_cast<uint64_t>(C_GameGUI2Module_Bytes + *(int32_t *)(C_GameGUI2Module_Bytes + 3) + 7);
+        uint64_t C_GameGUI2Module            = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
+        uint8_t *C_GameGUI2Module_Bytes      = reinterpret_cast<uint8_t *>(C_GameGUI2Module);
+        gPatterns.C_GameGUI2Module__Instance = reinterpret_cast<uint64_t>(C_GameGUI2Module_Bytes + *(int32_t *)(C_GameGUI2Module_Bytes + 3) + 7);
 
         gPatterns.C_GameGUI2Module__GetGameGui2Module           = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 40 80 F6 01");
         gPatterns.C_GameGUI2Module__SendHUDSimpleBooleanMessage = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 49 8B 97 ? ? ? ? 4C 8D 05 ? ? ? ?");
@@ -159,9 +159,9 @@ namespace SDK {
         gPatterns.C_GameTrafficModule__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 80 7E 07 00");
 
         // C_GfxEnvironmentEffects
-        uint64_t C_GfxEnvironmentEffects           = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 05 ? ? ? ? 48 8B 40 28 48 8B 40 28"));
-        uint8_t *C_GfxEnvironmentEffects_Bytes     = reinterpret_cast<uint8_t *>(C_GfxEnvironmentEffects);
-        gPatterns.C_GfxEnvironmentEffects_Instance = reinterpret_cast<uint64_t>(C_GfxEnvironmentEffects_Bytes + *(int32_t *)(C_GfxEnvironmentEffects_Bytes + 3) + 7);
+        uint64_t C_GfxEnvironmentEffects            = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 05 ? ? ? ? 48 8B 40 28 48 8B 40 28"));
+        uint8_t *C_GfxEnvironmentEffects_Bytes      = reinterpret_cast<uint8_t *>(C_GfxEnvironmentEffects);
+        gPatterns.C_GfxEnvironmentEffects__Instance = reinterpret_cast<uint64_t>(C_GfxEnvironmentEffects_Bytes + *(int32_t *)(C_GfxEnvironmentEffects_Bytes + 3) + 7);
 
         // C_HashName
         gPatterns.C_HashName__ComputeHash = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 74 24 ? 41 56 48 83 EC ? 4C 8B F2 48 8B F1 48 85 C9"));

--- a/code/client/src/sdk/patterns.cpp
+++ b/code/client/src/sdk/patterns.cpp
@@ -4,11 +4,11 @@ namespace SDK {
     Patterns gPatterns;
 
     void Patterns::InitPatterns() {
-        gPatterns.C_Entity__GameInitAddr   = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? 48 8B D9 8B 49 ? 8B C1 C1 E8 ? A8 ?").get_first());
-        gPatterns.C_Entity__GameDoneAddr   = reinterpret_cast<uint64_t>(hook::pattern("40 57 48 83 EC ? 8B 41 ? 48 8B F9 25 ? ? ? ?").get_first());
-        gPatterns.C_Entity__ActivateAddr   = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? 48 8B D9 8B 49 ? 8B C1 25 ? ? ? ?").get_first());
-        gPatterns.C_Entity__DeactivateAddr = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? 8B 41 ? 48 8B D9 25 ? ? ? ? 3D ? ? ? ?").get_first());
-        gPatterns.C_Entity__ReleaseAddr    = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 57 48 83 EC ? 8B 41 ? 48 8B D9 25 ? ? ? ?").get_first());
+        gPatterns.C_Entity__GameInit   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 8B 49 ? 8B C1 C1 E8 ? A8 ?"));
+        gPatterns.C_Entity__GameDone   = reinterpret_cast<uint64_t>(hook::get_pattern("40 57 48 83 EC ? 8B 41 ? 48 8B F9 25 ? ? ? ?"));
+        gPatterns.C_Entity__Activate   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 8B 49 ? 8B C1 25 ? ? ? ?"));
+        gPatterns.C_Entity__Deactivate = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 8B 41 ? 48 8B D9 25 ? ? ? ? 3D ? ? ? ?"));
+        gPatterns.C_Entity__Release    = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 8B 41 ? 48 8B D9 25 ? ? ? ?"));
 
         gPatterns.C_GameAudioModule__GetAudioModule = hook::get_opcode_address("E8 ? ? ? ? 48 8B C8 8D 53 51");
         gPatterns.C_GameAudioModule__SetCutsceneVolume = hook::get_opcode_address("E9 ? ? ? ? CC CC CC 48 8B 81 ? ? ? ? 89 90 ? ? ? ?");
@@ -25,44 +25,43 @@ namespace SDK {
 
         gPatterns.C_EntityList__GetEntityList = hook::get_opcode_address("E8 ? ? ? ? 8B 53 40 48 8B C8");
 
-        gPatterns.C_EntityFactory__ComputeHash    = reinterpret_cast<uint64_t>(hook::pattern("0F B6 11 33 C0 84 D2 74 2C").get_first());
-        gPatterns.C_EntityFactory__CreateEntity = hook::get_opcode_address("E8 ? ? ? ? 48 89 46 10 48 8B 4E 10");
-        gPatterns.C_EntityFactory__RegisterEntity = reinterpret_cast<uint64_t>(hook::pattern("48 83 EC 58 4C 8B C1").get_first());
+        gPatterns.C_EntityFactory__ComputeHash    = reinterpret_cast<uint64_t>(hook::get_pattern("0F B6 11 33 C0 84 D2 74 2C"));
+        gPatterns.C_EntityFactory__CreateEntity   = hook::get_opcode_address("E8 ? ? ? ? 48 89 46 10 48 8B 4E 10");
+        gPatterns.C_EntityFactory__RegisterEntity = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 58 4C 8B C1"));
 
-        gPatterns.C_PlayerModelManager__IsPlayerLoaded          = reinterpret_cast<uint64_t>(hook::pattern("48 8B 49 28 48 85 C9 75 03 ").get_first());
-        gPatterns.C_PlayerModelManager__SwitchPlayerProfileAddr = hook::get_opcode_address("E8 ? ? ? ? 48 8B C3 48 83 C4 20 5B C3 48 8B 41 48");
+        gPatterns.C_PlayerModelManager__IsPlayerLoaded      = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 49 28 48 85 C9 75 03"));
+        gPatterns.C_PlayerModelManager__SwitchPlayerProfile = hook::get_opcode_address("E8 ? ? ? ? 48 8B C3 48 83 C4 20 5B C3 48 8B 41 48");
 
-        gPatterns.C_ActorsSlotWrapper__C_ActorsSlotWrapperAddr  = reinterpret_cast<uint64_t>(hook::pattern("48 89 6C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC ? 48 8B 74 24 ? 48 8D 05 ? ? ? ? 33 ED").get_first());
-        gPatterns.C_ActorsSlotWrapper__UpdateToCreateActorsAddr = hook::get_opcode_address("E8 ? ? ? ? EB 25 83 FF 0A");
-        gPatterns.C_ActorsSlotWrapper__GetFreeActorAddr         = reinterpret_cast<uint64_t>(hook::pattern("41 56 48 83 EC ? 33 C0 48 8B F9").get_first(-0xA));
-        gPatterns.C_ActorsSlotWrapper__ReturnActorAddr          = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 56 48 83 EC ? 48 8B 41 ? 40 32 ED").get_first());
-        gPatterns.C_ActorsSlotWrapper__CloseAddr                = reinterpret_cast<uint64_t>(hook::pattern("40 53 55 48 83 EC ? C7 41 ? ? ? ? ?").get_first());
+        gPatterns.C_ActorsSlotWrapper__C_ActorsSlotWrapper  = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 6C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC ? 48 8B 74 24 ? 48 8D 05 ? ? ? ? 33 ED"));
+        gPatterns.C_ActorsSlotWrapper__UpdateToCreateActors = hook::get_opcode_address("E8 ? ? ? ? EB 25 83 FF 0A");
+        gPatterns.C_ActorsSlotWrapper__GetFreeActor         = reinterpret_cast<uint64_t>(hook::pattern("41 56 48 83 EC ? 33 C0 48 8B F9").get_first(-0xA));
+        gPatterns.C_ActorsSlotWrapper__ReturnActor          = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 56 48 83 EC ? 48 8B 41 ? 40 32 ED"));
+        gPatterns.C_ActorsSlotWrapper__Close                = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 55 48 83 EC ? C7 41 ? ? ? ? ?"));
 
-        gPatterns.C_SlotWrapper__LoadDataAddr = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B 41 ? 41 8B F9 49 8B F0 48 8B EA").get_first());
+        gPatterns.C_SlotWrapper__LoadData = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B 41 ? 41 8B F9 49 8B F0 48 8B EA"));
 
-        gPatterns.C_StreamingModule__SetStreamingPosSourceAddr = reinterpret_cast<uint64_t>(hook::pattern("33 C0 89 91 ? ? ? ? 48 89 81 ? ? ? ?").get_first());
+        gPatterns.C_StreamingModule__SetStreamingPosSource = reinterpret_cast<uint64_t>(hook::get_pattern("33 C0 89 91 ? ? ? ? 48 89 81 ? ? ? ?"));
 
-        gPatterns.C_HumanSpawner__C_HumanSpawnerVtblAddr          = hook::get_opcode_address("49 8B CE E8 ? ? ? ? 48 8B 5C 24 ? 48 8D 05 ? ? ? ?", 15);
-        gPatterns.C_HumanSpawner__SetupDefaultArchetypeObjectAddr = reinterpret_cast<uint64_t>(hook::pattern("4C 8B DC 49 89 5B ? 56 57 41 56 48 83 EC ? 48 8B 1D ? ? ? ?").get_first());
+        gPatterns.C_HumanSpawner__C_HumanSpawnerVtbl          = hook::get_opcode_address("49 8B CE E8 ? ? ? ? 48 8B 5C 24 ? 48 8D 05 ? ? ? ?", 15);
+        gPatterns.C_HumanSpawner__SetupDefaultArchetypeObject = reinterpret_cast<uint64_t>(hook::get_pattern("4C 8B DC 49 89 5B ? 56 57 41 56 48 83 EC ? 48 8B 1D ? ? ? ?"));
 
-        gPatterns.C_ProfileSpawner__C_ProfileSpawnerAddr      = hook::get_opcode_address("49 8B CE E8 ? ? ? ? 48 8B 5C 24 ? 48 8D 05 ? ? ? ?", 3);
-        gPatterns.C_ProfileSpawner__C_ProfileSpawnerDctorAddr = reinterpret_cast<uint64_t>(hook::pattern("40 53 56 57 48 83 EC ? 48 8D 05 ? ? ? ? 48 8B D9").get_first());
-        gPatterns.C_ProfileSpawner__IsSpawnProfileLoadedAddr  = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 E8 ? ? ? ? 48 8B C8 48 8D 54 24 ? E8 ? ? ? ? 4C 8D 83 ? ? ? ?").get_first());
-        gPatterns.C_ProfileSpawner__CreateActorAddr           = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? BA ? ? ? ? 48 89 4B 08");
-        gPatterns.C_ProfileSpawner__ReturnObjectAddr          = hook::get_opcode_address("E8 ? ? ? ? EB 6F 48 8B 5F 08");
+        gPatterns.C_ProfileSpawner__C_ProfileSpawner      = hook::get_opcode_address("49 8B CE E8 ? ? ? ? 48 8B 5C 24 ? 48 8D 05 ? ? ? ?", 3);
+        gPatterns.C_ProfileSpawner__C_ProfileSpawnerDctor = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 56 57 48 83 EC ? 48 8D 05 ? ? ? ? 48 8B D9"));
+        gPatterns.C_ProfileSpawner__IsSpawnProfileLoaded  = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 E8 ? ? ? ? 48 8B C8 48 8D 54 24 ? E8 ? ? ? ? 4C 8D 83 ? ? ? ?"));
+        gPatterns.C_ProfileSpawner__CreateActor           = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? BA ? ? ? ? 48 89 4B 08");
+        gPatterns.C_ProfileSpawner__ReturnObject          = hook::get_opcode_address("E8 ? ? ? ? EB 6F 48 8B 5F 08");
 
-        gPatterns.C_GameCamera__GetInstanceInternalAddr = hook::get_opcode_address("E8 ? ? ? ? 48 8B C8 4C 8D 4D 30");
+        gPatterns.C_GameCamera__GetInstanceInternal = hook::get_opcode_address("E8 ? ? ? ? 48 8B C8 4C 8D 4D 30");
 
-        gPatterns.C_WeatherManager2__GetDayTimeHoursAddr = reinterpret_cast<uint64_t>(hook::pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? F3 0F 10 81 ? ? ? ?").get_first());
-        gPatterns.C_WeatherManager2__GetDayTimeRelAddr   = reinterpret_cast<uint64_t>(hook::pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? 48 8B 41 ?").get_first());
-        gPatterns.C_WeatherManager2__SetDayTimeHoursAddr = reinterpret_cast<uint64_t>(hook::pattern("F3 0F 59 0D ? ? ? ? 0F 57 DB F3 0F 10 15 ? ? ? ? 0F 28 C1 F3 0F 5C C2 0F 2F C3 73 ? 0F 28 D1 F3 0F 10 0D ? ? ? ? 0F 28 C1 F3 "
-                                                                                                    "0F 5C C2 0F 2F C3 72 ? F3 0F 11 89 ? ? ? ? C3 F3 0F 11 91 ? ? ? ? C3 ? ? ? ? ? ? ? ? F3 0F 59 0D ? ? ? ?")
-                                                                                          .get_first());
-        gPatterns.C_WeatherManager2__SetDayTimeRelAddr   = reinterpret_cast<uint64_t>(hook::pattern("F3 0F 59 0D ? ? ? ? F3 0F 11 49 ? C3 ? ? F3 0F 59 0D ? ? ? ? 0F 57 DB").get_first());
-        gPatterns.C_WeatherManager2__SetWeatherSetAddr   = hook::get_opcode_address("E8 ? ? ? ? 48 8D 4F ? E8 ? ? ? ? E9 ? ? ? ? E8 ? ? ? ?");
+        gPatterns.C_WeatherManager2__GetDayTimeHours = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? F3 0F 10 81 ? ? ? ?"));
+        gPatterns.C_WeatherManager2__GetDayTimeRel   = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? 48 8B 41 ?"));
+        gPatterns.C_WeatherManager2__SetDayTimeHours = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 59 0D ? ? ? ? 0F 57 DB F3 0F 10 15 ? ? ? ? 0F 28 C1 F3 0F 5C C2 0F 2F C3 73 ? 0F 28 D1 F3 0F 10 0D ? ? ? ? 0F 28 C1 F3 "
+                                                                                                    "0F 5C C2 0F 2F C3 72 ? F3 0F 11 89 ? ? ? ? C3 F3 0F 11 91 ? ? ? ? C3 ? ? ? ? ? ? ? ? F3 0F 59 0D ? ? ? ?"));
+        gPatterns.C_WeatherManager2__SetDayTimeRel   = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 59 0D ? ? ? ? F3 0F 11 49 ? C3 ? ? F3 0F 59 0D ? ? ? ? 0F 57 DB"));
+        gPatterns.C_WeatherManager2__SetWeatherSet   = hook::get_opcode_address("E8 ? ? ? ? 48 8D 4F ? E8 ? ? ? ? E9 ? ? ? ? E8 ? ? ? ?");
 
-        gPatterns.I_Core__GetInstance             = hook::get_opcode_address("E8 ? ? ? ? 4C 8B 40 68");
-        gPatterns.C_SceneObject__SetTransformAddr = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? 48 8D 41 ? 48 8B D9 0F 10 02").get_first());
+        gPatterns.I_Core__GetInstance         = hook::get_opcode_address("E8 ? ? ? ? 4C 8B 40 68");
+        gPatterns.C_SceneObject__SetTransform = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8D 41 ? 48 8B D9 0F 10 02"));
 
         gPatterns.renameme__SpawnObject  = hook::get_opcode_address("E8 ? ? ? ? 33 F6 EB 9F");
         gPatterns.renameme__SpawnObject2 = hook::get_opcode_address("E8 ? ? ? ? 49 8B 4C 3F ?");
@@ -71,45 +70,50 @@ namespace SDK {
         gPatterns.I_VirtualFileSystemCache__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 41 0F B7 CF");
 
         gPatterns.I_GameDirector__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 48 8B 57 18 84 DB");
-        gPatterns.C_GameDirector__GetDistrict = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 50 F2 0F 10 02").get_first());
+        gPatterns.C_GameDirector__GetDistrict = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 50 F2 0F 10 02"));
 
         //NOTE: extract address from another function and its instruction
-        uint64_t C_MafiaFramework_Addr       = hook::get_opcode_address("E8 ? ? ? ? E8 ? ? ? ? 48 8B C8 48 8B 10 FF 92 ? ? ? ? 33 D2 48 8B C8") + 0xD;
-        uint8_t *C_MafiaFramework_Addr_Bytes = reinterpret_cast<uint8_t *>(C_MafiaFramework_Addr);
-        gPatterns.C_MafiaFramework__Instance = reinterpret_cast<uint64_t>(C_MafiaFramework_Addr_Bytes + *(int32_t *)(C_MafiaFramework_Addr_Bytes + 3) + 7);
+        uint64_t C_MafiaFramework            = hook::get_opcode_address("E8 ? ? ? ? E8 ? ? ? ? 48 8B C8 48 8B 10 FF 92 ? ? ? ? 33 D2 48 8B C8") + 0xD;
+        uint8_t *C_MafiaFramework_Bytes      = reinterpret_cast<uint8_t *>(C_MafiaFramework);
+        gPatterns.C_MafiaFramework__Instance = reinterpret_cast<uint64_t>(C_MafiaFramework_Bytes + *(int32_t *)(C_MafiaFramework_Bytes + 3) + 7);
 
-        uint64_t C_PlayerTeleportModule_Addr       = hook::get_opcode_address("E8 ? ? ? ? 83 78 38 00 74 13") + 0xD;
-        uint8_t *C_PlayerTeleportModule_Addr_Bytes = reinterpret_cast<uint8_t *>(C_PlayerTeleportModule_Addr);
-        gPatterns.C_PlayerTeleportModule__Instance = reinterpret_cast<uint64_t>(C_PlayerTeleportModule_Addr_Bytes + *(int32_t *)(C_PlayerTeleportModule_Addr_Bytes + 3) + 7);
+        uint64_t C_PlayerTeleportModule            = hook::get_opcode_address("E8 ? ? ? ? 83 78 38 00 74 13") + 0xD;
+        uint8_t *C_PlayerTeleportModule_Bytes      = reinterpret_cast<uint8_t *>(C_PlayerTeleportModule);
+        gPatterns.C_PlayerTeleportModule__Instance = reinterpret_cast<uint64_t>(C_PlayerTeleportModule_Bytes + *(int32_t *)(C_PlayerTeleportModule_Bytes + 3) + 7);
 
-        gPatterns.C_PlayerTeleportModule__TeleportPlayer = reinterpret_cast<uint64_t>(hook::pattern("40 56 48 83 EC 50 83 79 38 00").get_first());
+        gPatterns.C_PlayerTeleportModule__TeleportPlayer = reinterpret_cast<uint64_t>(hook::get_pattern("40 56 48 83 EC 50 83 79 38 00"));
 
-        uint64_t C_GfxEnvironmentEffects_Addr      = reinterpret_cast<uint64_t>(hook::pattern("48 8B 05 ? ? ? ? 48 8B 40 28 48 8B 40 28").get_first());
-        uint8_t *C_GfxEnvironmentEffects_Bytes     = reinterpret_cast<uint8_t *>(C_GfxEnvironmentEffects_Addr);
+        uint64_t C_GfxEnvironmentEffects           = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 05 ? ? ? ? 48 8B 40 28 48 8B 40 28"));
+        uint8_t *C_GfxEnvironmentEffects_Bytes     = reinterpret_cast<uint8_t *>(C_GfxEnvironmentEffects);
         gPatterns.C_GfxEnvironmentEffects_Instance = reinterpret_cast<uint64_t>(C_GfxEnvironmentEffects_Bytes + *(int32_t *)(C_GfxEnvironmentEffects_Bytes + 3) + 7);
 
-        uint64_t C_GameGui2Module_Addr      = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
-        uint8_t *C_GameGui2Module_Bytes     = reinterpret_cast<uint8_t *>(C_GameGui2Module_Addr);
-        gPatterns.C_GameGUI2Module_Instance = reinterpret_cast<uint64_t>(C_GameGui2Module_Bytes + *(int32_t *)(C_GameGui2Module_Bytes + 3) + 7);
+        // C_GameGui2Module
+        uint64_t C_GameGui2Module              = hook::get_opcode_address("E8 ? ? ? ? 41 8D 56 11");
+        uint8_t *C_GameGui2Module_Bytes        = reinterpret_cast<uint8_t *>(C_GameGui2Module);
+        gPatterns.C_GameGUI2Module_GetInstance = reinterpret_cast<uint64_t>(C_GameGui2Module_Bytes + *(int32_t *)(C_GameGui2Module_Bytes + 3) + 7);
 
-        gPatterns.C_Matrix__SetDir2Addr     = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? F2 0F 10 02 48 8B D9 8B 42 ?").get_first());
-        gPatterns.C_Matrix__SetDirAddr      = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 40 53 48 83 EC ? 48 8B D9 48 8D 4C 24 ?").get_first());
-        gPatterns.C_Matrix__SetDir3Addr     = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? F3 0F 10 02 0F 57 DB").get_first());
-        gPatterns.C_Matrix__SetRotAddr      = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ?").get_first());
-        gPatterns.C_Matrix__SetRotEulerAddr = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 0F 10 02").get_first());
+        gPatterns.C_GameGUI2Module_SendHUDSimpleBooleanMessage = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 49 8B 97 ? ? ? ? 4C 8D 05 ? ? ? ?");
+        gPatterns.C_GameGUI2Module_SendMessageMovie            = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8D 5D 58");
 
-        gPatterns.C_HashName__ComputeHashAddr = reinterpret_cast<uint64_t>(hook::pattern("48 89 74 24 ? 41 56 48 83 EC ? 4C 8B F2 48 8B F1 48 85 C9").get_first());
-        gPatterns.C_HashName__SetNameAddr     = reinterpret_cast<uint64_t>(hook::pattern("44 0F B6 11 4C 8B C2").get_first());
+        // C_Matrix
+        gPatterns.C_Matrix__SetDir2     = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F2 0F 10 02 48 8B D9 8B 42 ?"));
+        gPatterns.C_Matrix__SetDir      = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 40 53 48 83 EC ? 48 8B D9 48 8D 4C 24 ?"));
+        gPatterns.C_Matrix__SetDir3     = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F3 0F 10 02 0F 57 DB"));
+        gPatterns.C_Matrix__SetRot      = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ?"));
+        gPatterns.C_Matrix__SetRotEuler = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 33 C0 89 43 ? 89 43 ? 89 43 ? 48 83 C4 ? 5B C3 ? 0F 10 02"));
 
-        gPatterns.C_String__SetStringAddr = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B FA 48 8B F1 48 85 D2 75 ? 48 8B 09").get_first());
+        gPatterns.C_HashName__ComputeHash = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 74 24 ? 41 56 48 83 EC ? 4C 8B F2 48 8B F1 48 85 C9"));
+        gPatterns.C_HashName__SetName     = reinterpret_cast<uint64_t>(hook::get_pattern("44 0F B6 11 4C 8B C2"));
 
-        gPatterns.C_IE__AllocAddr = hook::get_opcode_address("48 ? ? 48 ? ? ? ? B9 04 14 00 00 E8 ? ? ? ? 48", 0xD);
-        gPatterns.C_IE__FreeAddr  = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 41 B8 0D 00 00 00 48 ? ? ? ? ? ? 48");
+        gPatterns.C_String__SetString = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B FA 48 8B F1 48 85 D2 75 ? 48 8B 09"));
+
+        gPatterns.C_IE__Alloc = hook::get_opcode_address("48 ? ? 48 ? ? ? ? B9 04 14 00 00 E8 ? ? ? ? 48", 0xD);
+        gPatterns.C_IE__Free  = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 41 B8 0D 00 00 00 48 ? ? ? ? ? ? 48");
 
         gPatterns.C_TickedModuleManager__GetTickedModuleManager = hook::get_opcode_address("E8 ? ? ? ? 45 8B 46 24");
 
-        gPatterns.C_Ctx__BeginUpdateAddr = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 48 89 51 ? 48 8D 4C 24 ?").get_first());
-        gPatterns.C_Ctx__EndUpdateAddr   = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? 48 83 79 ? ? 48 8B D9 74 ? 48 8D 4C 24 ? E8 ? ? ? ? 48 8D 4C 24 ?").get_first());
+        gPatterns.C_Ctx__BeginUpdate = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 48 89 51 ? 48 8D 4C 24 ?"));
+        gPatterns.C_Ctx__EndUpdate   = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 83 79 ? ? 48 8B D9 74 ? 48 8D 4C 24 ? E8 ? ? ? ? 48 8D 4C 24 ?"));
 
         gPatterns.C_CharacterController__ActivateHandler                           = hook::get_opcode_address("E8 ? ? ? ? 48 8D 56 74");
         gPatterns.C_CharacterController__DeactivateHandler_FromPlayerInput         = hook::get_opcode_address("E8 ? ? ? ? EB 0F 48 8B 93 ? ? ? ?");
@@ -123,13 +127,13 @@ namespace SDK {
         gPatterns.C_CharacterStateHandlerAim__UpdateAimAnimation                   = hook::get_opcode_address("E8 ? ? ? ? F3 0F 10 43 ? 48 8D 55 07");
 
         // C_HumanScript
-        gPatterns.C_HumanScript__GetOnVehicle  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 48 8B 5C 24 ? 48 85 C9 74 ? 83 69 ? ? 75 ? 48 8B 01 FF 50 ? 48 8B 06");
-        gPatterns.C_HumanScript__GetOffVehicle = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 48 85 C9 74 ? 83 69 ? ? 75 ? 48 8B 01 FF 50 ? 48 8B 8B ? ? ? ? 4C 8D 05 ? ? ? ?");
-        gPatterns.C_HumanScript__SetHealth     = reinterpret_cast<uint64_t>(hook::pattern("48 83 EC ? 48 8B 09 0F 29 74 24 ?").get_first());
-        gPatterns.C_HumanScript__ScrAim        = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 55 56 57 48 8B EC 48 83 EC 20 48 8B DA 48 8B F9 48 8B 0D ? ? ? ? 48 8D 55 20 41 0F B6 F0").get_first());
-        gPatterns.C_HumanScript__ScrAimAt = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 74 24 ? 55 57 41 56 48 8B EC 48 83 EC 30 48 8B DA").get_first());
-        gPatterns.C_HumanScript__ScrAttack     = reinterpret_cast<uint64_t>(hook::pattern("48 85 D2 0F 84 ? ? ? ? 55 56 41 56").get_first());
-        gPatterns.C_HumanScript__SetStealthMove = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 57 48 83 EC 60 48 8B F9 0F B6 DA").get_first());
+        gPatterns.C_HumanScript__GetOnVehicle   = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 48 8B 5C 24 ? 48 85 C9 74 ? 83 69 ? ? 75 ? 48 8B 01 FF 50 ? 48 8B 06");
+        gPatterns.C_HumanScript__GetOffVehicle  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 48 85 C9 74 ? 83 69 ? ? 75 ? 48 8B 01 FF 50 ? 48 8B 8B ? ? ? ? 4C 8D 05 ? ? ? ?");
+        gPatterns.C_HumanScript__SetHealth      = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC ? 48 8B 09 0F 29 74 24 ?"));
+        gPatterns.C_HumanScript__ScrAim         = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 55 56 57 48 8B EC 48 83 EC 20 48 8B DA 48 8B F9 48 8B 0D ? ? ? ? 48 8D 55 20 41 0F B6 F0"));
+        gPatterns.C_HumanScript__ScrAimAt       = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 55 57 41 56 48 8B EC 48 83 EC 30 48 8B DA"));
+        gPatterns.C_HumanScript__ScrAttack      = reinterpret_cast<uint64_t>(hook::get_pattern("48 85 D2 0F 84 ? ? ? ? 55 56 41 56"));
+        gPatterns.C_HumanScript__SetStealthMove = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC 60 48 8B F9 0F B6 DA"));
 
         // C_Quat
         gPatterns.C_Quat__SetDir = hook::get_opcode_address("E8 ? ? ? ? F3 44 0F 59 5D ?");
@@ -147,10 +151,9 @@ namespace SDK {
                                                              "? C7 00 ? ? ? ? 48 83 C0 ? 48 89 43 ? B8 ? ? ? ? 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? 48 83 EC ?");
 #endif
 
-        gPatterns.C_Car__CloseHood = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC ? 48 8B 81 ? ? ? ? 33 DB 48 2B 81 ? ? ? ? 33 FF 48 C1 F8 ? 48 8B F1 4C 63 F0 85 C0 0F 8E ? ? ? "
-                                                                              "? 48 89 6C 24 ? 0F 29 74 24 ? 0F 57 F6 66 66 0F 1F 84 00 ? ? ? ? 48 8B 86 ? ? ? ? 48 63 0C B8 48 8B 86 ? ? ? ? 48 8B 14 C8 33 C9 8B 42 ? 39 05 ? ? ? ? "
-                                                                              "48 0F 45 CA 48 85 C9 74 ? 48 0F BF 49 ? 48 8B 86 ? ? ? ? 48 8B 14 C8 0F 2F 72 ? 73 ? 0F B6 86 ? ? ? ? 48 8D 8E ? ? ? ? C0 E8 ? 45 33 C0")
-                                                                    .get_first());
+        gPatterns.C_Car__CloseHood = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56 48 83 EC ? 48 8B 81 ? ? ? ? 33 DB 48 2B 81 ? ? ? ? 33 FF 48 C1 F8 ? 48 8B F1 4C 63 F0 85 C0 0F 8E ? ? ? "
+                                                                                  "? 48 89 6C 24 ? 0F 29 74 24 ? 0F 57 F6 66 66 0F 1F 84 00 ? ? ? ? 48 8B 86 ? ? ? ? 48 63 0C B8 48 8B 86 ? ? ? ? 48 8B 14 C8 33 C9 8B 42 ? 39 05 ? ? ? ? "
+                                                                                  "48 0F 45 CA 48 85 C9 74 ? 48 0F BF 49 ? 48 8B 86 ? ? ? ? 48 8B 14 C8 0F 2F 72 ? 73 ? 0F B6 86 ? ? ? ? 48 8D 8E ? ? ? ? C0 E8 ? 45 33 C0"));
 
         gPatterns.C_Car__OpenTrunk  = hook::get_opcode_address("E8 ? ? ? ? 4D 85 F6 74 ? 49 8D 9E ? ? ? ?");
         gPatterns.C_Car__CloseTrunk = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4F ? 4C 8D 47 ? BA ? ? ? ? E8 ? ? ? ? 84 C0 0F 84 ? ? ? ?");
@@ -163,7 +166,7 @@ namespace SDK {
         gPatterns.C_Car__SetSpeed        = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 33 C0 48 83 C4 ? 5F C3 ? ? 48 83 EC ? 48 8B C2");
         gPatterns.C_Car__SetSeatStatus   = hook::get_opcode_address("E8 ? ? ? ? 45 85 F6 8B C5");
         gPatterns.C_Car__ExplodeCar      = hook::get_opcode_address("E8 ? ? ? ? 48 8B 86 ? ? ? ? 45 33 E4 48 2B 86 ? ? ? ?");
-        gPatterns.C_Car__ExplodeCar_2    = reinterpret_cast<uint64_t>(hook::pattern("F3 0F 11 4C 24 ? 4C 8B DC 55").get_first());
+        gPatterns.C_Car__ExplodeCar_2    = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 11 4C 24 ? 4C 8B DC 55"));
 
 #ifndef NONSTEAM_SUPPORT
         gPatterns.C_Car__PosefujZimuVShopu = hook::get_opcode_address("E8 ? ? ? ? 33 C0 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? 4C 8B 41 ?");
@@ -176,7 +179,7 @@ namespace SDK {
         gPatterns.C_Car__RestoreCar = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4B 10 0F 57 C9");
 #else
         //NOTE: todo
-        gPatterns.C_Car__RestoreCar   = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4B 10 0F 57 C9");
+        gPatterns.C_Car__RestoreCar = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4B 10 0F 57 C9");
 #endif
 
         // C_Motor
@@ -213,12 +216,11 @@ namespace SDK {
         gPatterns.C_Vehicle__SetSpeedLimit      = hook::get_opcode_address("E8 ? ? ? ? 48 8B 8B ? ? ? ? 48 85 C9 74 ? 48 8B 89 ? ? ? ?");
         gPatterns.C_Vehicle__SetSteer           = hook::get_opcode_address("E8 ? ? ? ? 45 33 C9 44 89 A7 ? ? ? ?");
         gPatterns.C_Vehicle__SetHorn            = hook::get_opcode_address("E8 ? ? ? ? 48 8B 0D ? ? ? ? 48 8B 01 FF 50 ? 8B F0");
-        gPatterns.C_Vehicle__TurnRadioOn        = reinterpret_cast<uint64_t>(hook::pattern("48 83 B9 ? ? ? ? ? 44 0F B6 CA").get_first());
-        gPatterns.C_Vehicle__ChangeRadioStation = reinterpret_cast<uint64_t>(hook::pattern("40 57 48 83 EC 20 48 83 B9 90 12 00 00 00").get_first());
-        gPatterns.C_Vehicle__DamageBreaks       = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? 48 8B 01 48 8B D9 0F 29 7C 24 ? 0F 28 F9 FF 50 ? 84 C0 74 ? 48 8B 5B ? 4C 8D 44 24 ? 0F 29 74 24 ? 48 8D 54 "
-                                                                                                 "24 ? 0F 57 F6 C7 44 24 ? ? ? ? ? C7 44 24 ? ? ? ? ? 48 8D 8B ? ? ? ? E8 ? ? ? ? F3 0F 10 0D ? ? ? ? 0F 28 C7 F3 0F 5C C1 0F "
-                                                                                                 "2F C6 73 ? 0F 28 CF 0F 28 C1 0F 57 05 ? ? ? ? 0F 2F C6 73 ? 0F 28 F1 F3 0F 59 35 ? ? ? ? 48 8D 8B ? ? ? ? F3 0F 10 54 24 ?")
-                                                                           .get_first());
+        gPatterns.C_Vehicle__TurnRadioOn        = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 B9 ? ? ? ? ? 44 0F B6 CA"));
+        gPatterns.C_Vehicle__ChangeRadioStation = reinterpret_cast<uint64_t>(hook::get_pattern("40 57 48 83 EC 20 48 83 B9 90 12 00 00 00"));
+        gPatterns.C_Vehicle__DamageBreaks       = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? 48 8B 01 48 8B D9 0F 29 7C 24 ? 0F 28 F9 FF 50 ? 84 C0 74 ? 48 8B 5B ? 4C 8D 44 24 ? 0F 29 74 24 ? 48 8D 54 "
+                                                                                                     "24 ? 0F 57 F6 C7 44 24 ? ? ? ? ? C7 44 24 ? ? ? ? ? 48 8D 8B ? ? ? ? E8 ? ? ? ? F3 0F 10 0D ? ? ? ? 0F 28 C7 F3 0F 5C C1 0F "
+                                                                                                     "2F C6 73 ? 0F 28 CF 0F 28 C1 0F 57 05 ? ? ? ? 0F 2F C6 73 ? 0F 28 F1 F3 0F 59 35 ? ? ? ? 48 8D 8B ? ? ? ? F3 0F 10 54 24 ?"));
         gPatterns.C_Vehicle__SetDoorFree        = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 33 C0 48 8B 74 24 ? 48 83 C4 ? 5F C3 ? ? ? 40 53 48 83 EC ? 45 33 C0 33 D2 48 8B D9 E8 ? ? ? ? 48 8B 43 ? C7 40 ? ? "
                                                                                   "? ? ? C7 00 ? ? ? ? 48 83 C0 ? 48 89 43 ? B8 ? ? ? ? 48 83 C4 ? 5B C3 ? ? ? ? ? ? ? ? ? B8 ? ? ? ?");
         gPatterns.C_Vehicle__SetSpeed           = hook::get_opcode_address("E8 ? ? ? ? 49 8B CF E8 ? ? ? ? 45 0F 57 C9");
@@ -233,26 +235,26 @@ namespace SDK {
         gPatterns.C_Vehicle__SetWheelTintColor  = hook::get_opcode_address("E8 ? ? ? ? 45 89 B7 ? ? ? ? 41 89 B7 ? ? ? ?");
 
         // C_Door
-        gPatterns.C_Door__Lock          = reinterpret_cast<uint64_t>(hook::pattern("F6 81 ? ? ? ? ? 48 8B D1 75 ? 83 B9 ? ? ? ? ? 74 ? 8B 89 ? ? ? ? 85 C9").get_first());
-        gPatterns.C_Door__AILock        = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? F6 81 ? ? ? ? ? 48 8B D9 75 ? 83 B9 ? ? ? ? ? 74 ? E8 ? ? ? ? 48 8B C8 41 B0 ? 48 8B D3 E8 ? ? ? ? 83 8B ? ? ? ? ?").get_first());
+        gPatterns.C_Door__Lock          = reinterpret_cast<uint64_t>(hook::get_pattern("F6 81 ? ? ? ? ? 48 8B D1 75 ? 83 B9 ? ? ? ? ? 74 ? 8B 89 ? ? ? ? 85 C9"));
+        gPatterns.C_Door__AILock        = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F6 81 ? ? ? ? ? 48 8B D9 75 ? 83 B9 ? ? ? ? ? 74 ? E8 ? ? ? ? 48 8B C8 41 B0 ? 48 8B D3 E8 ? ? ? ? 83 8B ? ? ? ? ?"));
         gPatterns.C_Door__Unlock        = hook::get_opcode_address("E8 ? ? ? ? EB ? 83 F8 ? 75 ? 48 8B 83 ? ? ? ?");
-        gPatterns.C_Door__AIUnlock      = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC ? F6 81 ? ? ? ? ? 48 8B D9 75 ? 83 B9 ? ? ? ? ? 74 ? E8 ? ? ? ? 48 8B C8 41 B0 ? 48 8B D3 E8 ? ? ? ? 83 A3 ? ? ? ? ?").get_first());
-        gPatterns.C_Door__StartLockpick = reinterpret_cast<uint64_t>(hook::pattern("F6 81 ? ? ? ? ? 75 ? 83 B9 ? ? ? ? ? 74 ? 48 81 C1 ? ? ? ? E9 ? ? ? ?").get_first());
-        gPatterns.C_Door__StopLockpick  = reinterpret_cast<uint64_t>(hook::pattern("F6 81 ? ? ? ? ? 75 ? 83 B9 ? ? ? ? ? 74 ? 83 B9 ? ? ? ? ? 75 ? 45 33 C0").get_first());
+        gPatterns.C_Door__AIUnlock      = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC ? F6 81 ? ? ? ? ? 48 8B D9 75 ? 83 B9 ? ? ? ? ? 74 ? E8 ? ? ? ? 48 8B C8 41 B0 ? 48 8B D3 E8 ? ? ? ? 83 A3 ? ? ? ? ?"));
+        gPatterns.C_Door__StartLockpick = reinterpret_cast<uint64_t>(hook::get_pattern("F6 81 ? ? ? ? ? 75 ? 83 B9 ? ? ? ? ? 74 ? 48 81 C1 ? ? ? ? E9 ? ? ? ?"));
+        gPatterns.C_Door__StopLockpick  = reinterpret_cast<uint64_t>(hook::get_pattern("F6 81 ? ? ? ? ? 75 ? 83 B9 ? ? ? ? ? 74 ? 83 B9 ? ? ? ? ? 75 ? 45 33 C0"));
         gPatterns.C_Door__Kick          = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 48 8B 42 ? 8B 48 ?");
         gPatterns.C_Door__Open          = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 83 B9 ? ? ? ? ? 0F 85 ? ? ? ?");
         gPatterns.C_Door__Close         = hook::get_opcode_address("E8 ? ? ? ? C6 86 ? ? ? ? ? 33 D2");
         gPatterns.C_Door__ToggleOpen    = hook::get_opcode_address("E8 ? ? ? ? EB ? 80 7A ? ? 74 ?");
         gPatterns.C_Door__EnableAction  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 33 C0 48 83 C4 ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? 48 83 EC ?");
-        gPatterns.C_Door__DisableAction = reinterpret_cast<uint64_t>(hook::pattern("83 A1 ? ? ? ? ? 48 8B 81 ? ? ? ? 48 85 C0").get_first());
+        gPatterns.C_Door__DisableAction = reinterpret_cast<uint64_t>(hook::get_pattern("83 A1 ? ? ? ? ? 48 8B 81 ? ? ? ? 48 85 C0"));
 
         // C_Human2CarWrapper
         gPatterns.C_Human2CarWrapper__GetSeatID = hook::get_opcode_address("E8 ? ? ? ? 3D ? ? ? ? 75 0E");
 
         // C_InventoryWrapper
-        gPatterns.C_InventoryWrapper__AddMoney  = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC 20 48 8B 41 68 48 8B DA 80 78 18 09 75 4E").get_first());
+        gPatterns.C_InventoryWrapper__AddMoney  = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 48 8B 41 68 48 8B DA 80 78 18 09 75 4E"));
         gPatterns.C_InventoryWrapper__AddWeapon = hook::get_opcode_address("E8 ? ? ? ? 41 38 76 4C 74 0C");
-        gPatterns.C_InventoryWrapper__TellMoney = reinterpret_cast<uint64_t>(hook::pattern("48 83 EC 28 48 8B 41 68 80 78 18 09").get_first());
+        gPatterns.C_InventoryWrapper__TellMoney = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 28 48 8B 41 68 80 78 18 09"));
 
         // C_HumanInventory
         gPatterns.C_HumanInventory__AddItem                       = hook::get_opcode_address("E8 ? ? ? ? E9 ? ? ? ? 41 8B D6");
@@ -266,76 +268,76 @@ namespace SDK {
         gPatterns.C_HumanInventory__CanFire                       = hook::get_opcode_address("E8 ? ? ? ? 84 C0 75 2E F6 83 ? ? ? ? ?");
         gPatterns.C_HumanInventory__CanReload                     = hook::get_opcode_address("E8 ? ? ? ? 3C 01 75 06");
         gPatterns.C_HumanInventory__CanUseMedkit                  = hook::get_opcode_address("E8 ? ? ? ? 84 C0 0F 84 ? ? ? ? 8B 93 ? ? ? ?");
-        gPatterns.C_HumanInventory__CreateDefaultItems            = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 57 41 56 41 57 48 83 EC 50 48 8B F9").get_first());
+        gPatterns.C_HumanInventory__CreateDefaultItems            = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 57 41 56 41 57 48 83 EC 50 48 8B F9"));
         gPatterns.C_HumanInventory__CreateModel                   = hook::get_opcode_address("E8 ? ? ? ? 4C 8D B7 ? ? ? ? 48 8B F0");
-        gPatterns.C_HumanInventory__DestroyModel                  = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 57 48 83 EC 40 48 83 B9 ? ? ? ? ? 0F B6 FA").get_first());
+        gPatterns.C_HumanInventory__DestroyModel                  = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 57 48 83 EC 40 48 83 B9 ? ? ? ? ? 0F B6 FA"));
         gPatterns.C_HumanInventory__DoReload                      = hook::get_opcode_address("E8 ? ? ? ? 49 8B D4 48 8D 8E ? ? ? ?");
         gPatterns.C_HumanInventory__DoShot                        = hook::get_opcode_address("E8 ? ? ? ? F7 87 ? ? ? ? ? ? ? ? 74 1B");
         gPatterns.C_HumanInventory__DuplicateWeaponModel          = hook::get_opcode_address("E8 ? ? ? ? 48 8B D8 48 8D 45 97");
         gPatterns.C_HumanInventory__GetSelectedAmmoCategory       = hook::get_opcode_address("E8 ? ? ? ? 3B C3 74 04");
         gPatterns.C_HumanInventory__SelectAnimSetting             = hook::get_opcode_address("E8 ? ? ? ? 84 C0 74 B6 B0 01");
         gPatterns.C_HumanInventory__SelectByItemID                = hook::get_opcode_address("E8 ? ? ? ? 48 8B 87 ? ? ? ? 48 8D 55 20");
-        gPatterns.C_HumanInventory__SelectNextWeapon              = reinterpret_cast<uint64_t>(hook::pattern("40 56 48 81 EC ? ? ? ? 48 8B 41 78").get_first());
+        gPatterns.C_HumanInventory__SelectNextWeapon              = reinterpret_cast<uint64_t>(hook::get_pattern("40 56 48 81 EC ? ? ? ? 48 8B 41 78"));
         gPatterns.C_HumanInventory__TellMedkit                    = hook::get_opcode_address("E8 ? ? ? ? 3B C7 7D 0C");
         gPatterns.C_HumanInventory__UseMedkit                     = hook::get_opcode_address("E8 ? ? ? ? 0F B6 D8 84 C0 74 28");
 
         // C_HumanWeaponController
-        gPatterns.C_HumanWeaponController__DoWeaponSelectByItemId = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 6C 24 18 48 89 74 24 20 57 48 83 EC 40 48 8B 81 60"));
-        gPatterns.C_HumanWeaponController__GetRightHandWeaponID   = hook::get_opcode_address("E8 ? ? ? ? 3B 46 78 ");
-        gPatterns.C_HumanWeaponController__IsThrownWeapon         = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 81 ? ? ? ? 8B 40 48"));
-        gPatterns.C_HumanWeaponController__GetShotPosDir          = hook::get_opcode_address("E8 ? ? ? ? F2 0F 10 44 24 ? 48 8B CF");
-        gPatterns.C_HumanWeaponController__ResetScatterCoef       = reinterpret_cast<uint64_t>(hook::get_pattern("40 57 48 83 EC 30 48 8B F9 0F 29 74 24 ?"));
-        gPatterns.C_HumanWeaponController__SetAiming              = hook::get_opcode_address("E8 ? ? ? ? 48 8B 43 10 48 8B 88 ? ? ? ? C6 41 14 00");
-        gPatterns.C_HumanWeaponController__SetCoverFlag           = hook::get_opcode_address("E8 ? ? ? ? 48 8D 97 ? ? ? ? 49 8B CE");
-        gPatterns.C_HumanWeaponController__SetFirePressedFlag     = reinterpret_cast<uint64_t>(hook::get_pattern("84 D2 75 11 33 C0"));
-        gPatterns.C_HumanWeaponController__SetStickMove           = reinterpret_cast<uint64_t>(hook::get_pattern("F2 0F 10 02 F2 0F 11 81 ? ? ? ? C3"));
-        gPatterns.C_HumanWeaponController__SetZoomFlag            = hook::get_opcode_address("E8 ? ? ? ? F6 87 ? ? ? ? ? 49 8B CE");
-        gPatterns.C_HumanWeaponController__DoShot                 = hook::get_opcode_address("E8 ? ? ? ? 0F B6 D8 84 DB 0F 84 ? ? ? ?");
+        gPatterns.C_HumanWeaponController__DoWeaponSelectByItemId     = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 6C 24 18 48 89 74 24 20 57 48 83 EC 40 48 8B 81 60"));
+        gPatterns.C_HumanWeaponController__GetRightHandWeaponID       = hook::get_opcode_address("E8 ? ? ? ? 3B 46 78 ");
+        gPatterns.C_HumanWeaponController__IsThrownWeapon             = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 81 ? ? ? ? 8B 40 48"));
+        gPatterns.C_HumanWeaponController__GetShotPosDir              = hook::get_opcode_address("E8 ? ? ? ? F2 0F 10 44 24 ? 48 8B CF");
+        gPatterns.C_HumanWeaponController__ResetScatterCoef           = reinterpret_cast<uint64_t>(hook::get_pattern("40 57 48 83 EC 30 48 8B F9 0F 29 74 24 ?"));
+        gPatterns.C_HumanWeaponController__SetAiming                  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 43 10 48 8B 88 ? ? ? ? C6 41 14 00");
+        gPatterns.C_HumanWeaponController__SetCoverFlag               = hook::get_opcode_address("E8 ? ? ? ? 48 8D 97 ? ? ? ? 49 8B CE");
+        gPatterns.C_HumanWeaponController__SetFirePressedFlag         = reinterpret_cast<uint64_t>(hook::get_pattern("84 D2 75 11 33 C0"));
+        gPatterns.C_HumanWeaponController__SetStickMove               = reinterpret_cast<uint64_t>(hook::get_pattern("F2 0F 10 02 F2 0F 11 81 ? ? ? ? C3"));
+        gPatterns.C_HumanWeaponController__SetZoomFlag                = hook::get_opcode_address("E8 ? ? ? ? F6 87 ? ? ? ? ? 49 8B CE");
+        gPatterns.C_HumanWeaponController__DoShot                     = hook::get_opcode_address("E8 ? ? ? ? 0F B6 D8 84 DB 0F 84 ? ? ? ?");
         gPatterns.C_HumanWeaponController__DoWeaponReloadShowMagazine = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4F 08 4C 8B C6 BA ? ? ? ? E8 ? ? ? ? 45 33 F6");
         gPatterns.C_HumanWeaponController__DoWeaponReloadDropMagazine = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 56 57 48 83 EC 60 B8 ? ? ? ?"));
-        gPatterns.C_HumanWeaponController__DoWeaponReloadInventory = reinterpret_cast<uint64_t>(hook::get_pattern("33 C0 44 8B C2 48 89 81 ? ? ? ?"));
+        gPatterns.C_HumanWeaponController__DoWeaponReloadInventory    = reinterpret_cast<uint64_t>(hook::get_pattern("33 C0 44 8B C2 48 89 81 ? ? ? ?"));
 
         // C_Human2
         gPatterns.C_Human2__EnableHumanClothes = hook::get_opcode_address("E8 ? ? ? ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 8B 7C 24 ? 48 83 C4 40 41 5E C3 CC CC 48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54");
         gPatterns.C_Human2__EnableShadows      = hook::get_opcode_address("E8 ? ? ? ? 80 7F 18 09 75 56");
 
         // C_Navigation
-        gPatterns.C_Navigation__GetInstance           = hook::get_opcode_address("E8 ? ? ? ? 49 8B 5E 60");
-        gPatterns.C_Navigation__EnableGPSCustomPath   = hook::get_opcode_address("E8 ? ? ? ? 4D 85 F6 0F 84 ? ? ? ? 4D 2B E6");
-        gPatterns.C_Navigation__SetUserMark           = hook::get_opcode_address("E8 ? ? ? ? 48 83 C4 ? C3 ? ? ? ? ? ? ? 48 89 5C 24 ? 57 48 83 EC ? 41 8B D8");
-        gPatterns.C_Navigation__RegisterHumanPlayer   = hook::get_opcode_address("E8 ? ? ? ? 48 83 C6 10 49 3B F7");
-        gPatterns.C_Navigation__RegisterHumanPolice   = reinterpret_cast<uint64_t>(hook::pattern("48 83 EC 38 45 33 C9 C6 44 24 ? ?").get_first());
-        gPatterns.C_Navigation__RegisterVehicleCommon = hook::get_opcode_address("E8 ? ? ? ? 89 87 ? ? ? ? 48 8B CF E8 ? ? ? ?");
+        gPatterns.C_Navigation__GetInstance               = hook::get_opcode_address("E8 ? ? ? ? 49 8B 5E 60");
+        gPatterns.C_Navigation__EnableGPSCustomPath       = hook::get_opcode_address("E8 ? ? ? ? 4D 85 F6 0F 84 ? ? ? ? 4D 2B E6");
+        gPatterns.C_Navigation__SetUserMark               = hook::get_opcode_address("E8 ? ? ? ? 48 83 C4 ? C3 ? ? ? ? ? ? ? 48 89 5C 24 ? 57 48 83 EC ? 41 8B D8");
+        gPatterns.C_Navigation__RegisterHumanPlayer       = hook::get_opcode_address("E8 ? ? ? ? 48 83 C6 10 49 3B F7");
+        gPatterns.C_Navigation__RegisterHumanPolice       = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 38 45 33 C9 C6 44 24 ? ?"));
+        gPatterns.C_Navigation__RegisterVehicleCommon     = hook::get_opcode_address("E8 ? ? ? ? 89 87 ? ? ? ? 48 8B CF E8 ? ? ? ?");
         gPatterns.C_Navigation__RegisterVehicleMoto       = hook::get_opcode_address("E8 ? ? ? ? 48 8B 74 24 ? 48 8B 5C 24 ? 48 83 C4 20 5F C3 8B 48 04");
-        gPatterns.C_Navigation__RegisterVehicleEntity = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 49 8B F0 48 8B DA 48 8B E9"));
+        gPatterns.C_Navigation__RegisterVehicleEntity     = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 49 8B F0 48 8B DA 48 8B E9"));
         gPatterns.C_Navigation__RegisterVehiclePolice     = hook::get_opcode_address("E8 ? ? ? ? 48 81 8E ? ? ? ? ? ? ? ? 89 86 ? ? ? ?");
         gPatterns.C_Navigation__RegisterVehiclePoliceBoat = hook::get_opcode_address("E8 ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 48 09 87 ? ? ? ? 48 8B 5C 24 ?");
         gPatterns.C_Navigation__RegisterVehiclePoliceMoto = hook::get_opcode_address("E8 ? ? ? ? 89 86 ? ? ? ? C6 86 ? ? ? ? ? 48 8B 5C 24 ?");
-        gPatterns.C_Navigation__RegisterVehicleTaxi   = hook::get_opcode_address("E8 ? ? ? ? 48 89 77 38 33 F6");
+        gPatterns.C_Navigation__RegisterVehicleTaxi       = hook::get_opcode_address("E8 ? ? ? ? 48 89 77 38 33 F6");
         gPatterns.C_Navigation__UnregisterId              = hook::get_opcode_address("E8 ? ? ? ? 39 BE ? ? ? ? 75 0A");
         gPatterns.C_Navigation__UnregisterHuman           = hook::get_opcode_address("E8 ? ? ? ? 8B 05 ? ? ? ? 48 8B 7C 24 ?");
-        gPatterns.C_Navigation__UnregisterVehicle     = hook::get_opcode_address("E8 ? ? ? ? 44 38 B6 ? ? ? ? 74 1B");
+        gPatterns.C_Navigation__UnregisterVehicle         = hook::get_opcode_address("E8 ? ? ? ? 44 38 B6 ? ? ? ? 74 1B");
 
         // init
-        gPatterns.C_InitDone_MafiaFrameworkAddr = reinterpret_cast<uint64_t>(hook::pattern("40 55 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 0F 57 C0").get_first());
-        gPatterns.LoadIntroAddr                 = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 55 56 57 48 83 EC ? 48 8B E9 B9 ? ? ? ?").get_first());
+        gPatterns.C_InitDone_MafiaFramework = reinterpret_cast<uint64_t>(hook::get_pattern("40 55 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 0F 57 C0"));
+        gPatterns.LoadIntro                 = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 55 56 57 48 83 EC ? 48 8B E9 B9 ? ? ? ?"));
 
         // C_CommandLine
-        gPatterns.C_CommandLine__FindCommandAddr = hook::get_opcode_address("E8 ? ? ? ? 40 88 7D BB");
+        gPatterns.C_CommandLine__FindCommand = hook::get_opcode_address("E8 ? ? ? ? 40 88 7D BB");
 
         // C_GameFramework
-        gPatterns.C_GameFramework__IsSuspendedAddr = reinterpret_cast<uint64_t>(hook::pattern("80 39 ? 74 ? 80 79 ? ?").get_first());
+        gPatterns.C_GameFramework__IsSuspended = reinterpret_cast<uint64_t>(hook::get_pattern("80 39 ? 74 ? 80 79 ? ?"));
 
         // C_GameTrafficModule
         gPatterns.C_GameTrafficModule__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 80 7E 07 00");
 
         // C_Fader
-        gPatterns.C_Fader__FadeIn = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4D 67 48 8B 9C 24 ? ? ? ?");
+        gPatterns.C_Fader__FadeIn  = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4D 67 48 8B 9C 24 ? ? ? ?");
         gPatterns.C_Fader__FadeOut = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4C 24 ? 0F 28 74 24 ? 48 85 C9 74 1E");
-        gPatterns.C_Fader__Reset   = reinterpret_cast<uint64_t>(hook::pattern("48 83 EC 38 80 B9 ? ? ? ? ? 74 34").get_first());
+        gPatterns.C_Fader__Reset   = reinterpret_cast<uint64_t>(hook::get_pattern("48 83 EC 38 80 B9 ? ? ? ? ? 74 34"));
 
         // C_ShotManager
-        gPatterns.C_ShotManager__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 49 8B 4D 18 48 8B F8");
+        gPatterns.C_ShotManager__GetInstance     = hook::get_opcode_address("E8 ? ? ? ? 49 8B 4D 18 48 8B F8");
         gPatterns.C_ShotManager__CreateExplosion = hook::get_opcode_address("E8 ? ? ? ? C6 83 ? ? ? ? ? 48 85 F6");
         gPatterns.C_ShotManager__CreateFire      = hook::get_opcode_address("E8 ? ? ? ? 48 8D 4D 88 89 87 ? ? ? ?");
 
@@ -346,44 +348,62 @@ namespace SDK {
         gPatterns.C_Explosion__Clear = hook::get_opcode_address("E8 ? ? ? ? 66 03 DD 75 E5");
 
         // Lua
-        gPatterns.Lua__pcallAddr      = hook::get_opcode_address("E8 ? ? ? ? 85 FF 78 2B");
-        gPatterns.Lua__loadbufferAddr = hook::get_opcode_address("E8 ? ? ? ? 85 C0 74 2F 48 8B 47 48");
-        gPatterns.Lua__tostringAddr   = reinterpret_cast<uint64_t>(hook::pattern("4C 8B C9 81 FA ? ? ? ? 7E 37").get_first());
-        gPatterns.Lua__isstringAddr   = hook::get_opcode_address("E8 ? ? ? ? 85 C0 74 5E 8B D3");
+        gPatterns.Lua__pcall      = hook::get_opcode_address("E8 ? ? ? ? 85 FF 78 2B");
+        gPatterns.Lua__loadbuffer = hook::get_opcode_address("E8 ? ? ? ? 85 C0 74 2F 48 8B 47 48");
+        gPatterns.Lua__tostring   = reinterpret_cast<uint64_t>(hook::get_pattern("4C 8B C9 81 FA ? ? ? ? 7E 37"));
+        gPatterns.Lua__isstring   = hook::get_opcode_address("E8 ? ? ? ? 85 C0 74 5E 8B D3");
 
         // C_StreamMap
-        gPatterns.C_StreamMap__CloseGame = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 48 8B A9 ? ? ? ? 4C 8B F1 48 C7 44 24 ? ? ? ? ? B9 ? ? ? ? C7 44 24 ? ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? CC 48 89 7C 24 ? 48 8D 78 08 48 89 28 "
-                                        "48 85 FF 74 03 48 89 37 48 8D 48 10 48 85 C9 74 34 8B 44 24 20 48 8D 71 08 89 01 48 8D 54 24 ? 48 8B 44 24 ? 48 8B CE 48 89 06 E8 ? ? ? ? 84 C0 75 11 48 83 3E 00 74 0B 48 8B CE E8 ? ? ? ? F0 FF 00 49 8B 8E ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? "
-                                        "48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF F0 0F C1 08 83 F9 01 75 08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? "
-                                        "48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC 40 53 48 83 EC 20 44 8B 41 10 48 8D 81 ? ? ? ? 48 89 81 ? ? ? ? 32 DB 41 8D 40 FF").get_first());
-        gPatterns.C_StreamMap__CloseMission = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 48 8B A9 ? ? ? ? 4C 8B F1 48 C7 44 24 ? ? ? ? ? B9 ? ? ? ? C7 44 24 ? ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? CC 48 89 7C 24 ? 48 8D 78 08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 48 10 48 85 C9 74 34 8B 44 24 20 48 8D 71 08 89 01 48 8D 54 24 ? 48 8B 44 24 ? 48 8B CE 48 89 06 E8 ? ? ? ? 84 C0 75 11 48 83 3E 00 74 0B 48 8B CE E8 ? ? ? ? F0 FF 00 49 8B 8E ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF F0 0F C1 08 83 F9 01 75 08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC 48 89 5C 24 ?").get_first());
-        gPatterns.C_StreamMap__ClosePart = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 48 8B A9 ? ? ? ? 4C 8B F1 48 C7 44 24 ? ? ? ? ? B9 ? ? ? ? C7 44 24 ? ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? CC 48 89 7C 24 ? 48 8D 78 08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 48 10 48 85 C9 74 34 8B 44 24 20 48 8D 71 08 89 01 48 8D 54 24 ? 48 8B 44 24 ? 48 8B CE 48 89 06 E8 ? ? ? ? 84 C0 75 11 48 83 3E 00 74 0B 48 8B CE E8 ? ? ? ? F0 FF 00 49 8B 8E ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF F0 0F C1 08 83 F9 01 75 08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC 40 53 48 83 EC 20 44 8B 41 10 48 8D 81 ? ? ? ? 48 89 81 ? ? ? ? 32 DB 41 8D 40 FD").get_first());
-        gPatterns.C_StreamMap__OpenGame = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 33 C0").get_first());
-        gPatterns.C_StreamMap__OpenMission = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 4C 8B F1 48 C7 44 24 ? ? ? ? ? 48 8D 4C 24 ? C7 44 24 ? ? ? ? ? E8 ? ? ? ? 49 8B AE ? ? ? ? B9 ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? CC 48 89 7C 24 ? 48 8D 78 08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 70 10 48 85 F6 74 34 8B 44 24 20 48 8D 54 24 ? 89 06 48 8D 4E 08 48 8B 44 24 ? 48 89 46 08 E8 ? ? ? ? 84 C0 75 13 48 83 7E ? ? 74 0C 48 8D 4E 08 E8 ? ? ? ? F0 FF 00 49 8B 8E ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF F0 0F C1 08 83 F9 01 75 08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC CC CC CC CC CC CC 40 53").get_first());
-        gPatterns.C_StreamMap__OpenPart =
-            reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 4C 8B F1 48 C7 44 24 ? ? ? ? ? 48 8D 4C 24 ? C7 44 24 ? ? ? ? ? E8 ? ? ? ? 49 8B AE ? ? ? ? B9 ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? "
-                                                     "CC 48 89 7C 24 ? 48 8D 78 08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 70 10 48 85 F6 74 34 8B 44 24 20 48 8D 54 24 ? 89 06 48 8D 4E 08 48 8B 44 24 ? 48 89 46 08 E8 ? ? ? ? 84 C0 75 13 48 83 7E ? ? 74 0C 48 8D 4E 08 E8 ? ? ? ? "
-                                                     "F0 FF 00 49 8B 8E ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF "
-                                                     "F0 0F C1 08 83 F9 01 75 08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC CC CC CC CC CC CC 48 89 5C 24 ?")
-                                           .get_first());
-        gPatterns.C_StreamMap__GetGame = reinterpret_cast<uint64_t>(hook::pattern("48 8B 41 10 48 85 C0 48 0F 44 05 ? ? ? ? C3 48 8B 81 ? ? ? ?").get_first());
-        gPatterns.C_StreamMap__GetMission = reinterpret_cast<uint64_t>(hook::pattern("48 8B 41 18 48 85 C0 48 0F 44 05 ? ? ? ? C3 48 8B 41 20").get_first());
-        gPatterns.C_StreamMap__GetPart    = reinterpret_cast<uint64_t>(hook::pattern("48 8B 41 20 48 85 C0 48 0F 44 05 ? ? ? ? C3 40 53").get_first());
+        gPatterns.C_StreamMap__CloseGame = reinterpret_cast<uint64_t>(
+            hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 48 8B A9 ? ? ? ? 4C 8B F1 48 C7 44 24 ? ? ? ? ? B9 ? ? ? ? C7 44 24 ? ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? CC 48 89 7C 24 ? 48 8D 78 08 48 89 28 "
+                              "48 85 FF 74 03 48 89 37 48 8D 48 10 48 85 C9 74 34 8B 44 24 20 48 8D 71 08 89 01 48 8D 54 24 ? 48 8B 44 24 ? 48 8B CE 48 89 06 E8 ? ? ? ? 84 C0 75 11 48 83 3E 00 74 0B 48 8B CE E8 ? ? ? ? F0 FF 00 49 8B 8E ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? "
+                              "48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF F0 0F C1 08 83 F9 01 75 08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? "
+                              "48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC 40 53 48 83 EC 20 44 8B 41 10 48 8D 81 ? ? ? ? 48 89 81 ? ? ? ? 32 DB 41 8D 40 FF"));
+        gPatterns.C_StreamMap__CloseMission = reinterpret_cast<uint64_t>(
+            hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 48 8B A9 ? ? ? ? 4C 8B F1 48 C7 44 24 ? ? ? ? ? B9 ? ? ? ? C7 44 24 ? ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? CC 48 89 7C 24 ? 48 8D 78 "
+                              "08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 48 10 48 85 C9 74 34 8B 44 24 20 48 8D 71 08 89 01 48 8D 54 24 ? 48 8B 44 24 ? 48 8B CE 48 89 06 E8 ? ? ? ? 84 C0 75 11 48 83 3E 00 74 0B 48 8B CE E8 ? ? ? ? F0 FF 00 49 8B 8E ? ? ? "
+                              "? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF F0 0F C1 08 83 F9 01 75 "
+                              "08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC 48 89 5C 24 ?"));
+        gPatterns.C_StreamMap__ClosePart = reinterpret_cast<uint64_t>(
+            hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 48 8B A9 ? ? ? ? 4C 8B F1 48 C7 44 24 ? ? ? ? ? B9 ? ? ? ? C7 44 24 ? ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? CC 48 89 7C 24 ? 48 8D 78 "
+                              "08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 48 10 48 85 C9 74 34 8B 44 24 20 48 8D 71 08 89 01 48 8D 54 24 ? 48 8B 44 24 ? 48 8B CE 48 89 06 E8 ? ? ? ? 84 C0 75 11 48 83 3E 00 74 0B 48 8B CE E8 ? ? ? ? F0 FF 00 49 8B 8E ? ? ? "
+                              "? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF F0 0F C1 08 83 F9 01 75 "
+                              "08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC 40 53 48 83 EC 20 44 8B 41 10 48 8D 81 ? ? ? ? 48 89 81 ? ? ? ? 32 DB 41 8D 40 FD"));
+        gPatterns.C_StreamMap__OpenGame    = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 33 C0"));
+        gPatterns.C_StreamMap__OpenMission = reinterpret_cast<uint64_t>(
+            hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 4C 8B F1 48 C7 44 24 ? ? ? ? ? 48 8D 4C 24 ? C7 44 24 ? ? ? ? ? E8 ? ? ? ? 49 8B AE ? ? ? ? B9 ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? "
+                              "CC 48 89 7C 24 ? 48 8D 78 08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 70 10 48 85 F6 74 34 8B 44 24 20 48 8D 54 24 ? 89 06 48 8D 4E 08 48 8B 44 24 ? 48 89 46 08 E8 ? ? ? ? 84 C0 75 13 48 83 7E ? ? 74 0C 48 8D 4E 08 E8 ? ? ? ? "
+                              "F0 FF 00 49 8B 8E ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF "
+                              "F0 0F C1 08 83 F9 01 75 08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC CC CC CC CC CC CC 40 53"));
+        gPatterns.C_StreamMap__OpenPart = reinterpret_cast<uint64_t>(
+            hook::get_pattern("48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 41 56 48 83 EC 30 4C 8B F1 48 C7 44 24 ? ? ? ? ? 48 8D 4C 24 ? C7 44 24 ? ? ? ? ? E8 ? ? ? ? 49 8B AE ? ? ? ? B9 ? ? ? ? 48 8B 75 08 E8 ? ? ? ? 48 8B D8 48 85 C0 75 07 FF 15 ? ? ? ? "
+                              "CC 48 89 7C 24 ? 48 8D 78 08 48 89 28 48 85 FF 74 03 48 89 37 48 8D 70 10 48 85 F6 74 34 8B 44 24 20 48 8D 54 24 ? 89 06 48 8D 4E 08 48 8B 44 24 ? 48 89 46 08 E8 ? ? ? ? 84 C0 75 13 48 83 7E ? ? 74 0C 48 8D 4E 08 E8 ? ? ? ? "
+                              "F0 FF 00 49 8B 8E ? ? ? ? 48 B8 ? ? ? ? ? ? ? ? 48 2B C1 48 83 F8 01 73 0E 48 8D 0D ? ? ? ? FF 15 ? ? ? ? CC 48 8D 41 01 49 89 86 ? ? ? ? 48 89 5D 08 48 8B 07 48 89 18 48 83 7C 24 ? ? 74 1E 48 8D 4C 24 ? E8 ? ? ? ? 83 C9 FF "
+                              "F0 0F C1 08 83 F9 01 75 08 48 8B C8 E8 ? ? ? ? 48 8B 7C 24 ? 48 8B 5C 24 ? 48 8B 6C 24 ? 48 8B 74 24 ? 48 83 C4 30 41 5E C3 CC CC CC CC CC CC CC CC CC CC 48 89 5C 24 ?"));
+        gPatterns.C_StreamMap__GetGame    = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 41 10 48 85 C0 48 0F 44 05 ? ? ? ? C3 48 8B 81 ? ? ? ?"));
+        gPatterns.C_StreamMap__GetMission = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 41 18 48 85 C0 48 0F 44 05 ? ? ? ? C3 48 8B 41 20"));
+        gPatterns.C_StreamMap__GetPart    = reinterpret_cast<uint64_t>(hook::get_pattern("48 8B 41 20 48 85 C0 48 0F 44 05 ? ? ? ? C3 40 53"));
 
         // C_DatabaseSystem
         gPatterns.C_DatabaseSystem__GetDatabase =
-            reinterpret_cast<uint64_t>(hook::pattern("4C 8B 51 08 4D 8B C2 49 8B 42 08 80 78 19 00 75 1B 4C 8B 0A 4C 39 48 20 73 06 48 8B 40 10 EB 06 4C 8B C0 48 8B 00 80 78 19 00 74 E8 4D 3B C2 74 09 49 8B 40 20 48 39 02 73 03 4D 8B C2 4D 3B C2 74 05").get_first());
-   
-        // C_MafiaDBS
-        gPatterns.C_MafiaDBS__GetVehiclesDatabase = reinterpret_cast<uint64_t>(hook::pattern("40 53 48 83 EC 20 48 8B DA 41 B8 06 00 00 00").get_first());
+            reinterpret_cast<uint64_t>(hook::get_pattern("4C 8B 51 08 4D 8B C2 49 8B 42 08 80 78 19 00 75 1B 4C 8B 0A 4C 39 48 20 73 06 48 8B 40 10 EB 06 4C 8B C0 48 8B 00 80 78 19 00 74 E8 4D 3B C2 74 09 49 8B 40 20 48 39 02 73 03 4D 8B C2 4D 3B C2 74 05"));
+
+        // C_MafiaDBs
+        gPatterns.C_MafiaDBs__GetTablesDatabase   = hook::get_opcode_address("E8 ? ? ? ? 48 8B F8 49 8B C7");
+        gPatterns.C_MafiaDBs__GetVehiclesDatabase = reinterpret_cast<uint64_t>(hook::get_pattern("40 53 48 83 EC 20 48 8B DA 41 B8 06 00 00 00"));
 
         // C_SysODB
         gPatterns.C_SysODB__GetInstance = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 41 B8 6F 50 30 4C");
 
         // C_VehiclesDatabase
-        gPatterns.C_VehiclesDatabase__GetVehiclesCount = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8B 4D 30 8B F8");
-        gPatterns.C_VehiclesDatabase__GetVehicleByID   = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B 41 30 33 FF 41 8B D8 48 8B F2 48 8B E9 39 78 18 76 79").get_first());
-        gPatterns.C_VehiclesDatabase__GetVehicleByIndex = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 08 48 89 74 24 10 48 89 7C 24 18 41 56 48 83 EC 20 48 8B 41 30 33 DB 41 8B F8 4C 8B F2 48 8B F1 39 58 18 76 34 0F 1F 80 00 00 00 00 8B D3 48 8B C8 E8 ? ? ? ? 33 D2 48 8B C8 4C 8B 00 41 FF 50 ? 4C 8B C0 8B 48 04 3B F9 72 2D 48 8B 46 30 2B F9 FF C3 3B 58 18 72 D3 49 C7 06 00 00 00 00 48 8B 5C 24 30 49 8B C6 48 8B 74 24 38 48 8B 7C 24 40 48 83 C4 20 41 5E C3 49 63 10 8B C7 48 69 C0 F0 00 00 00").get_first());
-        gPatterns.C_VehiclesDatabase__GetVehicleByModel = reinterpret_cast<uint64_t>(hook::pattern("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 48 89 7C 24 20 41 55 41 56 41 57 48 83 EC 20 48 8B 41").get_first());
- }
+        gPatterns.C_VehiclesDatabase__GetVehiclesCount  = hook::get_opcode_address<uint64_t>("E8 ? ? ? ? 48 8B 4D 30 8B F8");
+        gPatterns.C_VehiclesDatabase__GetVehicleByID    = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B 41 30 33 FF 41 8B D8 48 8B F2 48 8B E9 39 78 18 76 79"));
+        gPatterns.C_VehiclesDatabase__GetVehicleByIndex = reinterpret_cast<uint64_t>(
+            hook::get_pattern("48 89 5C 24 08 48 89 74 24 10 48 89 7C 24 18 41 56 48 83 EC 20 48 8B 41 30 33 DB 41 8B F8 4C 8B F2 48 8B F1 39 58 18 76 34 0F 1F 80 00 00 00 00 8B D3 48 8B C8 E8 ? ? ? ? 33 D2 48 8B C8 4C 8B 00 41 FF 50 ? 4C 8B C0 8B 48 04 "
+                              "3B F9 72 2D 48 8B 46 30 2B F9 FF C3 3B 58 18 72 D3 49 C7 06 00 00 00 00 48 8B 5C 24 30 49 8B C6 48 8B 74 24 38 48 8B 7C 24 40 48 83 C4 20 41 5E C3 49 63 10 8B C7 48 69 C0 F0 00 00 00"));
+        gPatterns.C_VehiclesDatabase__GetVehicleByModel = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 48 89 7C 24 20 41 55 41 56 41 57 48 83 EC 20 48 8B 41"));
+
+        // C_MenuSave
+        gPatterns.C_MenuSave__OpenDebugLoadChapterString = reinterpret_cast<uint64_t>(hook::get_pattern("48 89 5C 24 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ? 48 81 EC ? ? ? ? 4C 8B F9 4C 8B F2"));
+    }
 }; // namespace SDK

--- a/code/client/src/sdk/patterns.h
+++ b/code/client/src/sdk/patterns.h
@@ -126,7 +126,7 @@ namespace SDK {
 
         // C_GameGUI2Module
         uint64_t C_GameGUI2Module__GetGameGui2Module           = 0x0;
-        uint64_t C_GameGUI2Module__GetInstance                 = 0x0;
+        uint64_t C_GameGUI2Module__Instance                    = 0x0;
         uint64_t C_GameGUI2Module__SendHUDSimpleBooleanMessage = 0x0;
         uint64_t C_GameGUI2Module__SendMessageMovie            = 0x0;
 
@@ -138,7 +138,7 @@ namespace SDK {
         uint64_t C_GameTrafficModule__GetInstance = 0x0;
 
         // C_GfxEnvironmentEffects
-        uint64_t C_GfxEnvironmentEffects_Instance = 0x0;
+        uint64_t C_GfxEnvironmentEffects__Instance = 0x0;
 
         // C_HashName
         uint64_t C_HashName__ComputeHash = 0x0;

--- a/code/client/src/sdk/patterns.h
+++ b/code/client/src/sdk/patterns.h
@@ -125,9 +125,10 @@ namespace SDK {
         uint64_t C_GameFramework__IsSuspended = 0x0;
 
         // C_GameGUI2Module
-        uint64_t C_GameGUI2Module_GetInstance                 = 0x0;
-        uint64_t C_GameGUI2Module_SendHUDSimpleBooleanMessage = 0x0;
-        uint64_t C_GameGUI2Module_SendMessageMovie            = 0x0;
+        uint64_t C_GameGUI2Module__GetGameGui2Module           = 0x0;
+        uint64_t C_GameGUI2Module__GetInstance                 = 0x0;
+        uint64_t C_GameGUI2Module__SendHUDSimpleBooleanMessage = 0x0;
+        uint64_t C_GameGUI2Module__SendMessageMovie            = 0x0;
 
         // C_GameInputModule
         uint64_t C_GameInputModule__GetGameInputModule = 0x0;
@@ -214,6 +215,7 @@ namespace SDK {
         uint64_t C_InventoryWrapper__TellMoney = 0x0;
 
         // C_MafiaDBs
+        uint64_t C_MafiaDBs__GetMafiaDbs         = 0x0;
         uint64_t C_MafiaDBs__GetTablesDatabase   = 0x0;
         uint64_t C_MafiaDBs__GetVehiclesDatabase = 0x0;
 
@@ -255,8 +257,9 @@ namespace SDK {
         uint64_t C_PlayerModelManager__SwitchPlayerProfile = 0x0;
 
         // C_PlayerTeleportModule
-        uint64_t C_PlayerTeleportModule__Instance       = 0x0;
-        uint64_t C_PlayerTeleportModule__TeleportPlayer = 0x0;
+        uint64_t C_PlayerTeleportModule__GetPlayerTeleportModule = 0x0;
+        uint64_t C_PlayerTeleportModule__Instance                = 0x0;
+        uint64_t C_PlayerTeleportModule__TeleportPlayer          = 0x0;
 
         // C_ProfileSpawner
         uint64_t C_ProfileSpawner__C_ProfileSpawner      = 0x0;

--- a/code/client/src/sdk/patterns.h
+++ b/code/client/src/sdk/patterns.h
@@ -215,7 +215,7 @@ namespace SDK {
         uint64_t C_InventoryWrapper__TellMoney = 0x0;
 
         // C_MafiaDBs
-        uint64_t C_MafiaDBs__GetMafiaDbs         = 0x0;
+        uint64_t C_MafiaDBs__GetMafiaDBs         = 0x0;
         uint64_t C_MafiaDBs__GetTablesDatabase   = 0x0;
         uint64_t C_MafiaDBs__GetVehiclesDatabase = 0x0;
 

--- a/code/client/src/sdk/patterns.h
+++ b/code/client/src/sdk/patterns.h
@@ -7,225 +7,160 @@
 namespace SDK {
     class Patterns {
       public:
-        uint64_t C_Entity__GameInit   = 0x0;
-        uint64_t C_Entity__GameDone   = 0x0;
-        uint64_t C_Entity__Activate   = 0x0;
-        uint64_t C_Entity__Deactivate = 0x0;
-        uint64_t C_Entity__Release    = 0x0;
-
-        uint64_t C_Game__GetGame = 0x0;
-
-        uint64_t C_GameAudioModule__GetAudioModule = 0x0;
-        uint64_t C_GameAudioModule__SetMasterVolume = 0x0;
-        uint64_t C_GameAudioModule__SetDialogueVolume = 0x0;
-        uint64_t C_GameAudioModule__SetMusicVolume = 0x0;
-        uint64_t C_GameAudioModule__SetSfxVolume = 0x0;
-        uint64_t C_GameAudioModule__SetCutsceneVolume = 0x0;
-        uint64_t C_GameAudioModule__SetDynamicRange = 0x0;
-
-        uint64_t C_GameInputModule__GetGameInputModule = 0x0;
-        uint64_t C_GameInputModule__PauseInput         = 0x0;
-
-        uint64_t C_EntityList__GetEntityList = 0x0;
-
-        uint64_t C_EntityFactory__CreateEntity   = 0x0;
-        uint64_t C_EntityFactory__ComputeHash    = 0x0;
-        uint64_t C_EntityFactory__RegisterEntity = 0x0;
-
-        uint64_t C_PlayerModelManager__IsPlayerLoaded      = 0x0;
-        uint64_t C_PlayerModelManager__SwitchPlayerProfile = 0x0;
-
+        // C_ActorsSlotWrapper
         uint64_t C_ActorsSlotWrapper__C_ActorsSlotWrapper  = 0x0;
-        uint64_t C_ActorsSlotWrapper__UpdateToCreateActors = 0x0;
+        uint64_t C_ActorsSlotWrapper__Close                = 0x0;
         uint64_t C_ActorsSlotWrapper__GetFreeActor         = 0x0;
         uint64_t C_ActorsSlotWrapper__ReturnActor          = 0x0;
-        uint64_t C_ActorsSlotWrapper__Close                = 0x0;
+        uint64_t C_ActorsSlotWrapper__UpdateToCreateActors = 0x0;
 
-        uint64_t C_SlotWrapper__LoadData = 0x0;
+        // C_BehaviorCharacter
+        uint64_t C_BehaviorCharacter__SetWAnimVariable_float = 0x0;
 
-        uint64_t C_StreamingModule__SetStreamingPosSource = 0x0;
+        // C_Car
+        uint64_t C_Car__CloseHood         = 0x0;
+        uint64_t C_Car__CloseTrunk        = 0x0;
+        uint64_t C_Car__ExplodeCar        = 0x0;
+        uint64_t C_Car__ExplodeCar_2      = 0x0;
+        uint64_t C_Car__GetDamage         = 0x0;
+        uint64_t C_Car__GetMotorDamage    = 0x0;
+        uint64_t C_Car__Lock              = 0x0;
+        uint64_t C_Car__LockEntryPoints   = 0x0;
+        uint64_t C_Car__OpenHood          = 0x0;
+        uint64_t C_Car__OpenTrunk         = 0x0;
+        uint64_t C_Car__PosefujZimuVShopu = 0x0;
+        uint64_t C_Car__RestoreCar        = 0x0;
+        uint64_t C_Car__SetMotorDamage    = 0x0;
+        uint64_t C_Car__SetSeatStatus     = 0x0;
+        uint64_t C_Car__SetSpeed          = 0x0;
+        uint64_t C_Car__SetTransparency   = 0x0;
+        uint64_t C_Car__Unlock            = 0x0;
+        uint64_t C_Car__UnlockEntryPoints = 0x0;
 
-        uint64_t C_HumanSpawner__C_HumanSpawnerVtbl          = 0x0;
-        uint64_t C_HumanSpawner__SetupDefaultArchetypeObject = 0x0;
+        // C_CharacterController
+        uint64_t C_CharacterController__ActivateHandler                   = 0x0;
+        uint64_t C_CharacterController__DeactivateHandler_FromPlayerInput = 0x0;
+        uint64_t C_CharacterController__TriggerActorActionById            = 0x0;
 
-        uint64_t C_ProfileSpawner__C_ProfileSpawner      = 0x0;
-        uint64_t C_ProfileSpawner__C_ProfileSpawnerDctor = 0x0;
-        uint64_t C_ProfileSpawner__IsSpawnProfileLoaded  = 0x0;
-        uint64_t C_ProfileSpawner__CreateActor           = 0x0;
-        uint64_t C_ProfileSpawner__ReturnObject          = 0x0;
+        // C_CharacterStateHandlerAim
+        uint64_t C_CharacterStateHandlerAim__SwappingWeapon     = 0x0;
+        uint64_t C_CharacterStateHandlerAim__UpdateAimAnimation = 0x0;
 
+        // C_CharacterStateHandlerBaseLocomotion
+        uint64_t C_CharacterStateHandlerBaseLocomotion__AddRemoveSprintDescriptor = 0x0;
+        uint64_t C_CharacterStateHandlerBaseLocomotion__Idle2MoveTransitionActive = 0x0;
+
+        // C_CharacterStateHandlerMove
+        uint64_t C_CharacterStateHandlerMove__SharpTurnTransitionActive = 0x0;
+
+        // C_CommandLine
+        uint64_t C_CommandLine__FindCommand = 0x0;
+
+        // C_Ctx
+        uint64_t C_Ctx__BeginUpdate = 0x0;
+        uint64_t C_Ctx__EndUpdate   = 0x0;
+
+        // C_DatabaseSystem
+        uint64_t C_DatabaseSystem__GetDatabase = 0x0;
+
+        // C_Door
+        uint64_t C_Door__AILock        = 0x0;
+        uint64_t C_Door__AIUnlock      = 0x0;
+        uint64_t C_Door__Close         = 0x0;
+        uint64_t C_Door__DisableAction = 0x0;
+        uint64_t C_Door__EnableAction  = 0x0;
+        uint64_t C_Door__Kick          = 0x0;
+        uint64_t C_Door__Lock          = 0x0;
+        uint64_t C_Door__Open          = 0x0;
+        uint64_t C_Door__StartLockpick = 0x0;
+        uint64_t C_Door__StopLockpick  = 0x0;
+        uint64_t C_Door__ToggleOpen    = 0x0;
+        uint64_t C_Door__Unlock        = 0x0;
+
+        // C_Entity
+        uint64_t C_Entity__Activate   = 0x0;
+        uint64_t C_Entity__Deactivate = 0x0;
+        uint64_t C_Entity__GameDone   = 0x0;
+        uint64_t C_Entity__GameInit   = 0x0;
+        uint64_t C_Entity__Release    = 0x0;
+
+        // C_EntityFactory
+        uint64_t C_EntityFactory__ComputeHash    = 0x0;
+        uint64_t C_EntityFactory__CreateEntity   = 0x0;
+        uint64_t C_EntityFactory__RegisterEntity = 0x0;
+
+        // C_EntityList
+        uint64_t C_EntityList__GetEntityList = 0x0;
+
+        // C_Explosion
+        uint64_t C_Explosion__Clear = 0x0;
+
+        // C_Fader
+        uint64_t C_Fader__FadeIn  = 0x0;
+        uint64_t C_Fader__FadeOut = 0x0;
+        uint64_t C_Fader__Reset   = 0x0;
+
+        // C_Fire
+        uint64_t C_Fire__Clear = 0x0;
+
+        // C_Game
+        uint64_t C_Game__GetGame = 0x0;
+
+        // C_GameAudioModule
+        uint64_t C_GameAudioModule__GetAudioModule    = 0x0;
+        uint64_t C_GameAudioModule__SetCutsceneVolume = 0x0;
+        uint64_t C_GameAudioModule__SetDialogueVolume = 0x0;
+        uint64_t C_GameAudioModule__SetDynamicRange   = 0x0;
+        uint64_t C_GameAudioModule__SetMasterVolume   = 0x0;
+        uint64_t C_GameAudioModule__SetMusicVolume    = 0x0;
+        uint64_t C_GameAudioModule__SetSfxVolume      = 0x0;
+
+        // C_GameCamera
         uint64_t C_GameCamera__GetInstanceInternal = 0x0;
 
-        uint64_t C_WeatherManager2__GetDayTimeHours = 0x0;
-        uint64_t C_WeatherManager2__GetDayTimeRel   = 0x0;
-        uint64_t C_WeatherManager2__SetDayTimeHours = 0x0;
-        uint64_t C_WeatherManager2__SetDayTimeRel   = 0x0;
-        uint64_t C_WeatherManager2__SetWeatherSet   = 0x0;
+        // C_GameDirector
+        uint64_t C_GameDirector__GetDistrict = 0x0;
 
-        uint64_t I_Core__GetInstance        = 0x0;
-        uint64_t C_MafiaFramework__Instance = 0x0;
-
-        // C_GfxEnvironmentEffects
-        uint64_t C_GfxEnvironmentEffects_Instance = 0x0;
+        // C_GameFramework
+        uint64_t C_GameFramework__IsSuspended = 0x0;
 
         // C_GameGUI2Module
         uint64_t C_GameGUI2Module_GetInstance                 = 0x0;
         uint64_t C_GameGUI2Module_SendHUDSimpleBooleanMessage = 0x0;
         uint64_t C_GameGUI2Module_SendMessageMovie            = 0x0;
 
-        // C_PlayerTeleportModule
-        uint64_t C_PlayerTeleportModule__Instance       = 0x0;
-        uint64_t C_PlayerTeleportModule__TeleportPlayer = 0x0;
+        // C_GameInputModule
+        uint64_t C_GameInputModule__GetGameInputModule = 0x0;
+        uint64_t C_GameInputModule__PauseInput         = 0x0;
 
-        uint64_t I_GameDirector__GetInstance = 0x0;
-        uint64_t C_GameDirector__GetDistrict = 0x0;
+        // C_GameTrafficModule
+        uint64_t C_GameTrafficModule__GetInstance = 0x0;
 
-        uint64_t C_SceneObject__SetTransform = 0x0;
+        // C_GfxEnvironmentEffects
+        uint64_t C_GfxEnvironmentEffects_Instance = 0x0;
 
-        uint64_t renameme__SpawnObject  = 0x0;
-        uint64_t renameme__SpawnObject2 = 0x0;
-        uint64_t renameme__SpawnObject3 = 0x0;
-
-        uint64_t C_Matrix__SetDir2     = 0x0;
-        uint64_t C_Matrix__SetDir      = 0x0;
-        uint64_t C_Matrix__SetDir3     = 0x0;
-        uint64_t C_Matrix__SetRot      = 0x0;
-        uint64_t C_Matrix__SetRotEuler = 0x0;
-
+        // C_HashName
         uint64_t C_HashName__ComputeHash = 0x0;
         uint64_t C_HashName__SetName     = 0x0;
 
-        uint64_t C_String__SetString = 0x0;
-
-        uint64_t C_IE__Alloc = 0x0;
-        uint64_t C_IE__Free  = 0x0;
-
-        uint64_t C_TickedModuleManager__GetTickedModuleManager = 0x0;
-
-        uint64_t C_Ctx__BeginUpdate = 0x0;
-        uint64_t C_Ctx__EndUpdate   = 0x0;
-
-        uint64_t I_VirtualFileSystemCache__GetInstance = 0x0;
-
-        uint64_t C_CharacterController__ActivateHandler                           = 0x0;
-        uint64_t C_CharacterController__DeactivateHandler_FromPlayerInput         = 0x0;
-        uint64_t C_CharacterStateHandlerBaseLocomotion__Idle2MoveTransitionActive = 0x0;
-        uint64_t C_CharacterStateHandlerBaseLocomotion__AddRemoveSprintDescriptor = 0x0;
-        uint64_t C_CharacterStateHandlerMove__SharpTurnTransitionActive           = 0x0;
-        uint64_t C_WAnimPlaybackManager__PlayState                                = 0x0;
-        uint64_t C_BehaviorCharacter__SetWAnimVariable_float                      = 0x0;
-        uint64_t C_CharacterController__TriggerActorActionById                    = 0x0;
-        uint64_t C_CharacterStateHandlerAim__UpdateAimAnimation                   = 0x0;
-        uint64_t C_CharacterStateHandlerAim__SwappingWeapon                       = 0x0;
-
-        // C_HumanScript
-        uint64_t C_HumanScript__GetOnVehicle   = 0x0;
-        uint64_t C_HumanScript__GetOffVehicle  = 0x0;
-        uint64_t C_HumanScript__SetHealth      = 0x0;
-        uint64_t C_HumanScript__ScrAim         = 0x0;
-        uint64_t C_HumanScript__ScrAimAt       = 0x0;
-        uint64_t C_HumanScript__ScrAttack      = 0x0;
-        uint64_t C_HumanScript__SetStealthMove = 0x0;
-
-        // C_Quat
-        uint64_t C_Quat__SetDir = 0x0;
-
-        // C_Car
-        uint64_t C_Car__Lock   = 0x0;
-        uint64_t C_Car__Unlock = 0x0;
-
-        uint64_t C_Car__LockEntryPoints   = 0x0;
-        uint64_t C_Car__UnlockEntryPoints = 0x0;
-
-        uint64_t C_Car__OpenHood  = 0x0;
-        uint64_t C_Car__CloseHood = 0x0;
-
-        uint64_t C_Car__OpenTrunk  = 0x0;
-        uint64_t C_Car__CloseTrunk = 0x0;
-
-        uint64_t C_Car__SetMotorDamage = 0x0;
-        uint64_t C_Car__GetMotorDamage = 0x0;
-
-        uint64_t C_Car__GetDamage         = 0x0;
-        uint64_t C_Car__SetTransparency   = 0x0;
-        uint64_t C_Car__SetSpeed          = 0x0;
-        uint64_t C_Car__PosefujZimuVShopu = 0x0;
-        uint64_t C_Car__RestoreCar        = 0x0;
-        uint64_t C_Car__SetSeatStatus     = 0x0;
-        uint64_t C_Car__ExplodeCar        = 0x0;
-        uint64_t C_Car__ExplodeCar_2      = 0x0;
-
-        // C_Motor
-        uint64_t C_Motor__SetFuel = 0x0;
-
-        // C_Vehicle
-        uint64_t C_Vehicle__AddVehicleFlags    = 0x0;
-        uint64_t C_Vehicle__ClearVehicleFlags  = 0x0;
-        uint64_t C_Vehicle__SetVehicleMatrix   = 0x0;
-        uint64_t C_Vehicle__SetSPZText         = 0x0;
-        uint64_t C_Vehicle__GetSPZText         = 0x0;
-        uint64_t C_Vehicle__SetActive          = 0x0;
-        uint64_t C_Vehicle__Damage             = 0x0;
-        uint64_t C_Vehicle__SetBeaconLightsOn  = 0x0;
-        uint64_t C_Vehicle__EnableRadio        = 0x0;
-        uint64_t C_Vehicle__SetBrake           = 0x0;
-        uint64_t C_Vehicle__SetEngineOn        = 0x0;
-        uint64_t C_Vehicle__SetGear            = 0x0;
-        uint64_t C_Vehicle__SetHandbrake       = 0x0;
-        uint64_t C_Vehicle__SetPower           = 0x0;
-        uint64_t C_Vehicle__SetSearchLightsOn  = 0x0;
-        uint64_t C_Vehicle__SetSiren           = 0x0;
-        uint64_t C_Vehicle__SetSpeedLimit      = 0x0;
-        uint64_t C_Vehicle__SetSteer           = 0x0;
-        uint64_t C_Vehicle__SetHorn            = 0x0;
-        uint64_t C_Vehicle__TurnRadioOn        = 0x0;
-        uint64_t C_Vehicle__ChangeRadioStation = 0x0;
-        uint64_t C_Vehicle__DamageBreaks       = 0x0;
-        uint64_t C_Vehicle__SetDoorFree        = 0x0;
-        uint64_t C_Vehicle__SetSpeed           = 0x0;
-        uint64_t C_Vehicle__SetAngularSpeed    = 0x0;
-        uint64_t C_Vehicle__IsActive           = 0x0;
-        uint64_t C_Vehicle__IsSiren            = 0x0;
-        uint64_t C_Vehicle__SetVehicleDirty    = 0x0;
-        uint64_t C_Vehicle__SetVehicleRust     = 0x0;
-        uint64_t C_Vehicle__SetVehicleColor    = 0x0;
-        uint64_t C_Vehicle__SetInteriorColors  = 0x0;
-        uint64_t C_Vehicle__SetWindowTintColor = 0x0;
-        uint64_t C_Vehicle__SetWheelTintColor  = 0x0;
-
-        // C_Door
-        uint64_t C_Door__Lock          = 0x0;
-        uint64_t C_Door__AILock        = 0x0;
-        uint64_t C_Door__Unlock        = 0x0;
-        uint64_t C_Door__AIUnlock      = 0x0;
-        uint64_t C_Door__StartLockpick = 0x0;
-        uint64_t C_Door__StopLockpick  = 0x0;
-        uint64_t C_Door__Kick          = 0x0;
-        uint64_t C_Door__Open          = 0x0;
-        uint64_t C_Door__Close         = 0x0;
-        uint64_t C_Door__ToggleOpen    = 0x0;
-        uint64_t C_Door__EnableAction  = 0x0;
-        uint64_t C_Door__DisableAction = 0x0;
+        // C_Human2
+        uint64_t C_Human2__EnableHumanClothes = 0x0;
+        uint64_t C_Human2__EnableShadows      = 0x0;
 
         // C_Human2CarWrapper
         uint64_t C_Human2CarWrapper__GetSeatID = 0x0;
 
-        // C_InventoryWrapper
-        uint64_t C_InventoryWrapper__AddMoney  = 0x0;
-        uint64_t C_InventoryWrapper__AddWeapon = 0x0;
-        uint64_t C_InventoryWrapper__TellMoney = 0x0;
-
         // C_HumanInventory
         uint64_t C_HumanInventory__AddItem                       = 0x0;
         uint64_t C_HumanInventory__AddItemByData                 = 0x0;
-        uint64_t C_HumanInventory__AddWeapon                     = 0x0;
         uint64_t C_HumanInventory__AddMedkits                    = 0x0;
+        uint64_t C_HumanInventory__AddWeapon                     = 0x0;
         uint64_t C_HumanInventory__CanAddAmmoByCategoryAux       = 0x0;
         uint64_t C_HumanInventory__CanAddAmmoByCategoryAuxAndMag = 0x0;
         uint64_t C_HumanInventory__CanAddUpgrade                 = 0x0;
+        uint64_t C_HumanInventory__CanAddWeapon                  = 0x0;
         uint64_t C_HumanInventory__CanFire                       = 0x0;
         uint64_t C_HumanInventory__CanReload                     = 0x0;
-        uint64_t C_HumanInventory__CanAddWeapon                  = 0x0;
         uint64_t C_HumanInventory__CanUseMedkit                  = 0x0;
         uint64_t C_HumanInventory__CreateDefaultItems            = 0x0;
         uint64_t C_HumanInventory__CreateModel                   = 0x0;
@@ -240,7 +175,24 @@ namespace SDK {
         uint64_t C_HumanInventory__TellMedkit                    = 0x0;
         uint64_t C_HumanInventory__UseMedkit                     = 0x0;
 
+        // C_HumanScript
+        uint64_t C_HumanScript__GetOffVehicle  = 0x0;
+        uint64_t C_HumanScript__GetOnVehicle   = 0x0;
+        uint64_t C_HumanScript__ScrAim         = 0x0;
+        uint64_t C_HumanScript__ScrAimAt       = 0x0;
+        uint64_t C_HumanScript__ScrAttack      = 0x0;
+        uint64_t C_HumanScript__SetHealth      = 0x0;
+        uint64_t C_HumanScript__SetStealthMove = 0x0;
+
+        // C_HumanSpawner
+        uint64_t C_HumanSpawner__C_HumanSpawnerVtbl          = 0x0;
+        uint64_t C_HumanSpawner__SetupDefaultArchetypeObject = 0x0;
+
         // C_HumanWeaponController
+        uint64_t C_HumanWeaponController__DoShot                     = 0x0;
+        uint64_t C_HumanWeaponController__DoWeaponReloadDropMagazine = 0x0;
+        uint64_t C_HumanWeaponController__DoWeaponReloadInventory    = 0x0;
+        uint64_t C_HumanWeaponController__DoWeaponReloadShowMagazine = 0x0;
         uint64_t C_HumanWeaponController__DoWeaponSelectByItemId     = 0x0;
         uint64_t C_HumanWeaponController__GetRightHandWeaponID       = 0x0;
         uint64_t C_HumanWeaponController__GetShotPosDir              = 0x0;
@@ -251,65 +203,84 @@ namespace SDK {
         uint64_t C_HumanWeaponController__SetFirePressedFlag         = 0x0;
         uint64_t C_HumanWeaponController__SetStickMove               = 0x0;
         uint64_t C_HumanWeaponController__SetZoomFlag                = 0x0;
-        uint64_t C_HumanWeaponController__DoShot                     = 0x0;
-        uint64_t C_HumanWeaponController__DoWeaponReloadDropMagazine = 0x0;
-        uint64_t C_HumanWeaponController__DoWeaponReloadShowMagazine = 0x0;
-        uint64_t C_HumanWeaponController__DoWeaponReloadInventory    = 0x0;
 
-        uint64_t C_Human2__EnableShadows      = 0x0;
-        uint64_t C_Human2__EnableHumanClothes = 0x0;
+        // C_IE
+        uint64_t C_IE__Alloc = 0x0;
+        uint64_t C_IE__Free  = 0x0;
+
+        // C_InventoryWrapper
+        uint64_t C_InventoryWrapper__AddMoney  = 0x0;
+        uint64_t C_InventoryWrapper__AddWeapon = 0x0;
+        uint64_t C_InventoryWrapper__TellMoney = 0x0;
+
+        // C_MafiaDBs
+        uint64_t C_MafiaDBs__GetTablesDatabase   = 0x0;
+        uint64_t C_MafiaDBs__GetVehiclesDatabase = 0x0;
+
+        // C_MafiaFramework
+        uint64_t C_MafiaFramework__Instance = 0x0;
+
+        // C_Matrix
+        uint64_t C_Matrix__SetDir      = 0x0;
+        uint64_t C_Matrix__SetDir2     = 0x0;
+        uint64_t C_Matrix__SetDir3     = 0x0;
+        uint64_t C_Matrix__SetRot      = 0x0;
+        uint64_t C_Matrix__SetRotEuler = 0x0;
+
+        // C_MenuSave
+        uint64_t C_MenuSave__OpenDebugLoadChapterString = 0x0;
+
+        // C_Motor
+        uint64_t C_Motor__SetFuel = 0x0;
 
         // C_Navigation
-        uint64_t C_Navigation__GetInstance               = 0x0;
         uint64_t C_Navigation__EnableGPSCustomPath       = 0x0;
-        uint64_t C_Navigation__SetUserMark               = 0x0;
+        uint64_t C_Navigation__GetInstance               = 0x0;
         uint64_t C_Navigation__RegisterHumanPlayer       = 0x0;
         uint64_t C_Navigation__RegisterHumanPolice       = 0x0;
         uint64_t C_Navigation__RegisterVehicleCommon     = 0x0;
-        uint64_t C_Navigation__RegisterVehicleMoto       = 0x0;
         uint64_t C_Navigation__RegisterVehicleEntity     = 0x0;
+        uint64_t C_Navigation__RegisterVehicleMoto       = 0x0;
         uint64_t C_Navigation__RegisterVehiclePolice     = 0x0;
         uint64_t C_Navigation__RegisterVehiclePoliceBoat = 0x0;
         uint64_t C_Navigation__RegisterVehiclePoliceMoto = 0x0;
         uint64_t C_Navigation__RegisterVehicleTaxi       = 0x0;
-        uint64_t C_Navigation__UnregisterId              = 0x0;
+        uint64_t C_Navigation__SetUserMark               = 0x0;
         uint64_t C_Navigation__UnregisterHuman           = 0x0;
+        uint64_t C_Navigation__UnregisterId              = 0x0;
         uint64_t C_Navigation__UnregisterVehicle         = 0x0;
 
-        // init
-        uint64_t C_InitDone_MafiaFramework = 0x0;
-        uint64_t LoadIntro                 = 0x0;
+        // C_PlayerModelManager
+        uint64_t C_PlayerModelManager__IsPlayerLoaded      = 0x0;
+        uint64_t C_PlayerModelManager__SwitchPlayerProfile = 0x0;
 
-        // C_CommandLine
-        uint64_t C_CommandLine__FindCommand = 0x0;
+        // C_PlayerTeleportModule
+        uint64_t C_PlayerTeleportModule__Instance       = 0x0;
+        uint64_t C_PlayerTeleportModule__TeleportPlayer = 0x0;
 
-        // C_GameFramework
-        uint64_t C_GameFramework__IsSuspended = 0x0;
+        // C_ProfileSpawner
+        uint64_t C_ProfileSpawner__C_ProfileSpawner      = 0x0;
+        uint64_t C_ProfileSpawner__C_ProfileSpawnerDctor = 0x0;
+        uint64_t C_ProfileSpawner__CreateActor           = 0x0;
+        uint64_t C_ProfileSpawner__IsSpawnProfileLoaded  = 0x0;
+        uint64_t C_ProfileSpawner__ReturnObject          = 0x0;
 
-        // C_GameTrafficModule
-        uint64_t C_GameTrafficModule__GetInstance = 0x0;
+        // C_Quat
+        uint64_t C_Quat__SetDir = 0x0;
 
-        // C_Fader
-        uint64_t C_Fader__FadeIn  = 0x0;
-        uint64_t C_Fader__FadeOut = 0x0;
-        uint64_t C_Fader__Reset   = 0x0;
+        // C_SceneObject
+        uint64_t C_SceneObject__SetTransform = 0x0;
 
         // C_ShotManager
-        uint64_t C_ShotManager__GetInstance     = 0x0;
         uint64_t C_ShotManager__CreateExplosion = 0x0;
         uint64_t C_ShotManager__CreateFire      = 0x0;
+        uint64_t C_ShotManager__GetInstance     = 0x0;
 
-        // C_Fire
-        uint64_t C_Fire__Clear = 0x0;
+        // C_SlotWrapper
+        uint64_t C_SlotWrapper__LoadData = 0x0;
 
-        // C_Explosion
-        uint64_t C_Explosion__Clear = 0x0;
-
-        // Lua
-        uint64_t Lua__pcall      = 0x0;
-        uint64_t Lua__loadbuffer = 0x0;
-        uint64_t Lua__tostring   = 0x0;
-        uint64_t Lua__isstring   = 0x0;
+        // C_StreamingModule
+        uint64_t C_StreamingModule__SetStreamingPosSource = 0x0;
 
         // C_StreamMap
         uint64_t C_StreamMap__CloseGame    = 0x0;
@@ -322,24 +293,89 @@ namespace SDK {
         uint64_t C_StreamMap__OpenMission  = 0x0;
         uint64_t C_StreamMap__OpenPart     = 0x0;
 
-        // C_DatabaseSystem
-        uint64_t C_DatabaseSystem__GetDatabase = 0x0;
+        // C_String
+        uint64_t C_String__SetString = 0x0;
 
         // C_SysODB
         uint64_t C_SysODB__GetInstance = 0x0;
 
-        // C_MafiaDBs
-        uint64_t C_MafiaDBs__GetVehiclesDatabase = 0x0;
-        uint64_t C_MafiaDBs__GetTablesDatabase   = 0x0;
+        // C_TickedModuleManager
+        uint64_t C_TickedModuleManager__GetTickedModuleManager = 0x0;
+
+        // C_Vehicle
+        uint64_t C_Vehicle__AddVehicleFlags    = 0x0;
+        uint64_t C_Vehicle__ChangeRadioStation = 0x0;
+        uint64_t C_Vehicle__ClearVehicleFlags  = 0x0;
+        uint64_t C_Vehicle__Damage             = 0x0;
+        uint64_t C_Vehicle__DamageBreaks       = 0x0;
+        uint64_t C_Vehicle__EnableRadio        = 0x0;
+        uint64_t C_Vehicle__GetSPZText         = 0x0;
+        uint64_t C_Vehicle__IsActive           = 0x0;
+        uint64_t C_Vehicle__IsSiren            = 0x0;
+        uint64_t C_Vehicle__SetActive          = 0x0;
+        uint64_t C_Vehicle__SetAngularSpeed    = 0x0;
+        uint64_t C_Vehicle__SetBeaconLightsOn  = 0x0;
+        uint64_t C_Vehicle__SetBrake           = 0x0;
+        uint64_t C_Vehicle__SetDoorFree        = 0x0;
+        uint64_t C_Vehicle__SetEngineOn        = 0x0;
+        uint64_t C_Vehicle__SetGear            = 0x0;
+        uint64_t C_Vehicle__SetHandbrake       = 0x0;
+        uint64_t C_Vehicle__SetHorn            = 0x0;
+        uint64_t C_Vehicle__SetInteriorColors  = 0x0;
+        uint64_t C_Vehicle__SetPower           = 0x0;
+        uint64_t C_Vehicle__SetSearchLightsOn  = 0x0;
+        uint64_t C_Vehicle__SetSiren           = 0x0;
+        uint64_t C_Vehicle__SetSpeed           = 0x0;
+        uint64_t C_Vehicle__SetSpeedLimit      = 0x0;
+        uint64_t C_Vehicle__SetSPZText         = 0x0;
+        uint64_t C_Vehicle__SetSteer           = 0x0;
+        uint64_t C_Vehicle__SetVehicleColor    = 0x0;
+        uint64_t C_Vehicle__SetVehicleDirty    = 0x0;
+        uint64_t C_Vehicle__SetVehicleMatrix   = 0x0;
+        uint64_t C_Vehicle__SetVehicleRust     = 0x0;
+        uint64_t C_Vehicle__SetWheelTintColor  = 0x0;
+        uint64_t C_Vehicle__SetWindowTintColor = 0x0;
+        uint64_t C_Vehicle__TurnRadioOn        = 0x0;
 
         // C_VehiclesDatabase
-        uint64_t C_VehiclesDatabase__GetVehiclesCount  = 0x0;
-        uint64_t C_VehiclesDatabase__GetVehicleByIndex = 0x0;
         uint64_t C_VehiclesDatabase__GetVehicleByID    = 0x0;
+        uint64_t C_VehiclesDatabase__GetVehicleByIndex = 0x0;
         uint64_t C_VehiclesDatabase__GetVehicleByModel = 0x0;
+        uint64_t C_VehiclesDatabase__GetVehiclesCount  = 0x0;
 
-        // C_MenuSave
-        uint64_t C_MenuSave__OpenDebugLoadChapterString = 0x0;
+        // C_WAnimPlaybackManager
+        uint64_t C_WAnimPlaybackManager__PlayState = 0x0;
+
+        // C_WeatherManager2
+        uint64_t C_WeatherManager2__GetDayTimeHours = 0x0;
+        uint64_t C_WeatherManager2__GetDayTimeRel   = 0x0;
+        uint64_t C_WeatherManager2__SetDayTimeHours = 0x0;
+        uint64_t C_WeatherManager2__SetDayTimeRel   = 0x0;
+        uint64_t C_WeatherManager2__SetWeatherSet   = 0x0;
+
+        // I_Core
+        uint64_t I_Core__GetInstance = 0x0;
+
+        // I_GameDirector
+        uint64_t I_GameDirector__GetInstance = 0x0;
+
+        // I_VirtualFileSystemCache
+        uint64_t I_VirtualFileSystemCache__GetInstance = 0x0;
+
+        // Lua
+        uint64_t Lua__isstring   = 0x0;
+        uint64_t Lua__loadbuffer = 0x0;
+        uint64_t Lua__pcall      = 0x0;
+        uint64_t Lua__tostring   = 0x0;
+
+        // init
+        uint64_t C_InitDone_MafiaFramework = 0x0;
+        uint64_t LoadIntro                 = 0x0;
+
+        // TODO: rename me
+        uint64_t renameme__SpawnObject  = 0x0;
+        uint64_t renameme__SpawnObject2 = 0x0;
+        uint64_t renameme__SpawnObject3 = 0x0;
 
         static void InitPatterns();
     };

--- a/code/client/src/sdk/patterns.h
+++ b/code/client/src/sdk/patterns.h
@@ -7,11 +7,11 @@
 namespace SDK {
     class Patterns {
       public:
-        uint64_t C_Entity__GameInitAddr   = 0x0;
-        uint64_t C_Entity__GameDoneAddr   = 0x0;
-        uint64_t C_Entity__ActivateAddr   = 0x0;
-        uint64_t C_Entity__DeactivateAddr = 0x0;
-        uint64_t C_Entity__ReleaseAddr    = 0x0;
+        uint64_t C_Entity__GameInit   = 0x0;
+        uint64_t C_Entity__GameDone   = 0x0;
+        uint64_t C_Entity__Activate   = 0x0;
+        uint64_t C_Entity__Deactivate = 0x0;
+        uint64_t C_Entity__Release    = 0x0;
 
         uint64_t C_Game__GetGame = 0x0;
 
@@ -28,75 +28,82 @@ namespace SDK {
 
         uint64_t C_EntityList__GetEntityList = 0x0;
 
-        uint64_t C_EntityFactory__CreateEntity = 0x0;
+        uint64_t C_EntityFactory__CreateEntity   = 0x0;
         uint64_t C_EntityFactory__ComputeHash    = 0x0;
         uint64_t C_EntityFactory__RegisterEntity = 0x0;
 
-        uint64_t C_PlayerModelManager__IsPlayerLoaded          = 0x0;
-        uint64_t C_PlayerModelManager__SwitchPlayerProfileAddr = 0x0;
+        uint64_t C_PlayerModelManager__IsPlayerLoaded      = 0x0;
+        uint64_t C_PlayerModelManager__SwitchPlayerProfile = 0x0;
 
-        uint64_t C_ActorsSlotWrapper__C_ActorsSlotWrapperAddr  = 0x0;
-        uint64_t C_ActorsSlotWrapper__UpdateToCreateActorsAddr = 0x0;
-        uint64_t C_ActorsSlotWrapper__GetFreeActorAddr         = 0x0;
-        uint64_t C_ActorsSlotWrapper__ReturnActorAddr          = 0x0;
-        uint64_t C_ActorsSlotWrapper__CloseAddr                = 0x0;
+        uint64_t C_ActorsSlotWrapper__C_ActorsSlotWrapper  = 0x0;
+        uint64_t C_ActorsSlotWrapper__UpdateToCreateActors = 0x0;
+        uint64_t C_ActorsSlotWrapper__GetFreeActor         = 0x0;
+        uint64_t C_ActorsSlotWrapper__ReturnActor          = 0x0;
+        uint64_t C_ActorsSlotWrapper__Close                = 0x0;
 
-        uint64_t C_SlotWrapper__LoadDataAddr = 0x0;
+        uint64_t C_SlotWrapper__LoadData = 0x0;
 
-        uint64_t C_StreamingModule__SetStreamingPosSourceAddr = 0x0;
+        uint64_t C_StreamingModule__SetStreamingPosSource = 0x0;
 
-        uint64_t C_HumanSpawner__C_HumanSpawnerVtblAddr          = 0x0;
-        uint64_t C_HumanSpawner__SetupDefaultArchetypeObjectAddr = 0x0;
+        uint64_t C_HumanSpawner__C_HumanSpawnerVtbl          = 0x0;
+        uint64_t C_HumanSpawner__SetupDefaultArchetypeObject = 0x0;
 
-        uint64_t C_ProfileSpawner__C_ProfileSpawnerAddr      = 0x0;
-        uint64_t C_ProfileSpawner__C_ProfileSpawnerDctorAddr = 0x0;
-        uint64_t C_ProfileSpawner__IsSpawnProfileLoadedAddr  = 0x0;
-        uint64_t C_ProfileSpawner__CreateActorAddr           = 0x0;
-        uint64_t C_ProfileSpawner__ReturnObjectAddr          = 0x0;
+        uint64_t C_ProfileSpawner__C_ProfileSpawner      = 0x0;
+        uint64_t C_ProfileSpawner__C_ProfileSpawnerDctor = 0x0;
+        uint64_t C_ProfileSpawner__IsSpawnProfileLoaded  = 0x0;
+        uint64_t C_ProfileSpawner__CreateActor           = 0x0;
+        uint64_t C_ProfileSpawner__ReturnObject          = 0x0;
 
-        uint64_t C_GameCamera__GetInstanceInternalAddr = 0x0;
+        uint64_t C_GameCamera__GetInstanceInternal = 0x0;
 
-        uint64_t C_WeatherManager2__GetDayTimeHoursAddr = 0x0;
-        uint64_t C_WeatherManager2__GetDayTimeRelAddr   = 0x0;
-        uint64_t C_WeatherManager2__SetDayTimeHoursAddr = 0x0;
-        uint64_t C_WeatherManager2__SetDayTimeRelAddr   = 0x0;
-        uint64_t C_WeatherManager2__SetWeatherSetAddr   = 0x0;
+        uint64_t C_WeatherManager2__GetDayTimeHours = 0x0;
+        uint64_t C_WeatherManager2__GetDayTimeRel   = 0x0;
+        uint64_t C_WeatherManager2__SetDayTimeHours = 0x0;
+        uint64_t C_WeatherManager2__SetDayTimeRel   = 0x0;
+        uint64_t C_WeatherManager2__SetWeatherSet   = 0x0;
 
-        uint64_t I_Core__GetInstance              = 0x0;
-        uint64_t C_MafiaFramework__Instance       = 0x0;
+        uint64_t I_Core__GetInstance        = 0x0;
+        uint64_t C_MafiaFramework__Instance = 0x0;
+
+        // C_GfxEnvironmentEffects
         uint64_t C_GfxEnvironmentEffects_Instance = 0x0;
-        uint64_t C_GameGUI2Module_Instance        = 0x0;
 
-        uint64_t C_PlayerTeleportModule__Instance = 0x0;
+        // C_GameGUI2Module
+        uint64_t C_GameGUI2Module_GetInstance                 = 0x0;
+        uint64_t C_GameGUI2Module_SendHUDSimpleBooleanMessage = 0x0;
+        uint64_t C_GameGUI2Module_SendMessageMovie            = 0x0;
+
+        // C_PlayerTeleportModule
+        uint64_t C_PlayerTeleportModule__Instance       = 0x0;
         uint64_t C_PlayerTeleportModule__TeleportPlayer = 0x0;
 
         uint64_t I_GameDirector__GetInstance = 0x0;
         uint64_t C_GameDirector__GetDistrict = 0x0;
 
-        uint64_t C_SceneObject__SetTransformAddr = 0x0;
+        uint64_t C_SceneObject__SetTransform = 0x0;
 
         uint64_t renameme__SpawnObject  = 0x0;
         uint64_t renameme__SpawnObject2 = 0x0;
         uint64_t renameme__SpawnObject3 = 0x0;
 
-        uint64_t C_Matrix__SetDir2Addr     = 0x0;
-        uint64_t C_Matrix__SetDirAddr      = 0x0;
-        uint64_t C_Matrix__SetDir3Addr     = 0x0;
-        uint64_t C_Matrix__SetRotAddr      = 0x0;
-        uint64_t C_Matrix__SetRotEulerAddr = 0x0;
+        uint64_t C_Matrix__SetDir2     = 0x0;
+        uint64_t C_Matrix__SetDir      = 0x0;
+        uint64_t C_Matrix__SetDir3     = 0x0;
+        uint64_t C_Matrix__SetRot      = 0x0;
+        uint64_t C_Matrix__SetRotEuler = 0x0;
 
-        uint64_t C_HashName__ComputeHashAddr = 0x0;
-        uint64_t C_HashName__SetNameAddr     = 0x0;
+        uint64_t C_HashName__ComputeHash = 0x0;
+        uint64_t C_HashName__SetName     = 0x0;
 
-        uint64_t C_String__SetStringAddr = 0x0;
+        uint64_t C_String__SetString = 0x0;
 
-        uint64_t C_IE__AllocAddr = 0x0;
-        uint64_t C_IE__FreeAddr  = 0x0;
+        uint64_t C_IE__Alloc = 0x0;
+        uint64_t C_IE__Free  = 0x0;
 
         uint64_t C_TickedModuleManager__GetTickedModuleManager = 0x0;
 
-        uint64_t C_Ctx__BeginUpdateAddr = 0x0;
-        uint64_t C_Ctx__EndUpdateAddr   = 0x0;
+        uint64_t C_Ctx__BeginUpdate = 0x0;
+        uint64_t C_Ctx__EndUpdate   = 0x0;
 
         uint64_t I_VirtualFileSystemCache__GetInstance = 0x0;
 
@@ -112,12 +119,12 @@ namespace SDK {
         uint64_t C_CharacterStateHandlerAim__SwappingWeapon                       = 0x0;
 
         // C_HumanScript
-        uint64_t C_HumanScript__GetOnVehicle  = 0x0;
-        uint64_t C_HumanScript__GetOffVehicle = 0x0;
-        uint64_t C_HumanScript__SetHealth     = 0x0;
-        uint64_t C_HumanScript__ScrAim   = 0x0;
-        uint64_t C_HumanScript__ScrAimAt = 0x0;
-        uint64_t C_HumanScript__ScrAttack     = 0x0;
+        uint64_t C_HumanScript__GetOnVehicle   = 0x0;
+        uint64_t C_HumanScript__GetOffVehicle  = 0x0;
+        uint64_t C_HumanScript__SetHealth      = 0x0;
+        uint64_t C_HumanScript__ScrAim         = 0x0;
+        uint64_t C_HumanScript__ScrAimAt       = 0x0;
+        uint64_t C_HumanScript__ScrAttack      = 0x0;
         uint64_t C_HumanScript__SetStealthMove = 0x0;
 
         // C_Quat
@@ -143,7 +150,7 @@ namespace SDK {
         uint64_t C_Car__SetTransparency   = 0x0;
         uint64_t C_Car__SetSpeed          = 0x0;
         uint64_t C_Car__PosefujZimuVShopu = 0x0;
-        uint64_t C_Car__RestoreCar           = 0x0;
+        uint64_t C_Car__RestoreCar        = 0x0;
         uint64_t C_Car__SetSeatStatus     = 0x0;
         uint64_t C_Car__ExplodeCar        = 0x0;
         uint64_t C_Car__ExplodeCar_2      = 0x0;
@@ -234,61 +241,61 @@ namespace SDK {
         uint64_t C_HumanInventory__UseMedkit                     = 0x0;
 
         // C_HumanWeaponController
-        uint64_t C_HumanWeaponController__DoWeaponSelectByItemId = 0x0;
-        uint64_t C_HumanWeaponController__GetRightHandWeaponID   = 0x0;
-        uint64_t C_HumanWeaponController__GetShotPosDir          = 0x0;
-        uint64_t C_HumanWeaponController__IsThrownWeapon         = 0x0;
-        uint64_t C_HumanWeaponController__ResetScatterCoef       = 0x0;
-        uint64_t C_HumanWeaponController__SetAiming              = 0x0;
-        uint64_t C_HumanWeaponController__SetCoverFlag           = 0x0;
-        uint64_t C_HumanWeaponController__SetFirePressedFlag     = 0x0;
-        uint64_t C_HumanWeaponController__SetStickMove           = 0x0;
-        uint64_t C_HumanWeaponController__SetZoomFlag            = 0x0;
-        uint64_t C_HumanWeaponController__DoShot                 = 0x0;
+        uint64_t C_HumanWeaponController__DoWeaponSelectByItemId     = 0x0;
+        uint64_t C_HumanWeaponController__GetRightHandWeaponID       = 0x0;
+        uint64_t C_HumanWeaponController__GetShotPosDir              = 0x0;
+        uint64_t C_HumanWeaponController__IsThrownWeapon             = 0x0;
+        uint64_t C_HumanWeaponController__ResetScatterCoef           = 0x0;
+        uint64_t C_HumanWeaponController__SetAiming                  = 0x0;
+        uint64_t C_HumanWeaponController__SetCoverFlag               = 0x0;
+        uint64_t C_HumanWeaponController__SetFirePressedFlag         = 0x0;
+        uint64_t C_HumanWeaponController__SetStickMove               = 0x0;
+        uint64_t C_HumanWeaponController__SetZoomFlag                = 0x0;
+        uint64_t C_HumanWeaponController__DoShot                     = 0x0;
         uint64_t C_HumanWeaponController__DoWeaponReloadDropMagazine = 0x0;
         uint64_t C_HumanWeaponController__DoWeaponReloadShowMagazine = 0x0;
-        uint64_t C_HumanWeaponController__DoWeaponReloadInventory = 0x0;
+        uint64_t C_HumanWeaponController__DoWeaponReloadInventory    = 0x0;
 
-        uint64_t C_Human2__EnableShadows = 0x0;
+        uint64_t C_Human2__EnableShadows      = 0x0;
         uint64_t C_Human2__EnableHumanClothes = 0x0;
 
         // C_Navigation
-        uint64_t C_Navigation__GetInstance           = 0x0;
-        uint64_t C_Navigation__EnableGPSCustomPath   = 0x0;
-        uint64_t C_Navigation__SetUserMark           = 0x0;
-        uint64_t C_Navigation__RegisterHumanPlayer   = 0x0;
-        uint64_t C_Navigation__RegisterHumanPolice   = 0x0;
-        uint64_t C_Navigation__RegisterVehicleCommon = 0x0;
+        uint64_t C_Navigation__GetInstance               = 0x0;
+        uint64_t C_Navigation__EnableGPSCustomPath       = 0x0;
+        uint64_t C_Navigation__SetUserMark               = 0x0;
+        uint64_t C_Navigation__RegisterHumanPlayer       = 0x0;
+        uint64_t C_Navigation__RegisterHumanPolice       = 0x0;
+        uint64_t C_Navigation__RegisterVehicleCommon     = 0x0;
         uint64_t C_Navigation__RegisterVehicleMoto       = 0x0;
-        uint64_t C_Navigation__RegisterVehicleEntity = 0x0;
+        uint64_t C_Navigation__RegisterVehicleEntity     = 0x0;
         uint64_t C_Navigation__RegisterVehiclePolice     = 0x0;
         uint64_t C_Navigation__RegisterVehiclePoliceBoat = 0x0;
         uint64_t C_Navigation__RegisterVehiclePoliceMoto = 0x0;
-        uint64_t C_Navigation__RegisterVehicleTaxi   = 0x0;
+        uint64_t C_Navigation__RegisterVehicleTaxi       = 0x0;
         uint64_t C_Navigation__UnregisterId              = 0x0;
         uint64_t C_Navigation__UnregisterHuman           = 0x0;
-        uint64_t C_Navigation__UnregisterVehicle     = 0x0;
+        uint64_t C_Navigation__UnregisterVehicle         = 0x0;
 
         // init
-        uint64_t C_InitDone_MafiaFrameworkAddr = 0x0;
-        uint64_t LoadIntroAddr                 = 0x0;
+        uint64_t C_InitDone_MafiaFramework = 0x0;
+        uint64_t LoadIntro                 = 0x0;
 
         // C_CommandLine
-        uint64_t C_CommandLine__FindCommandAddr = 0x0;
+        uint64_t C_CommandLine__FindCommand = 0x0;
 
         // C_GameFramework
-        uint64_t C_GameFramework__IsSuspendedAddr = 0x0;
+        uint64_t C_GameFramework__IsSuspended = 0x0;
 
         // C_GameTrafficModule
         uint64_t C_GameTrafficModule__GetInstance = 0x0;
 
         // C_Fader
-        uint64_t C_Fader__FadeIn = 0x0;
+        uint64_t C_Fader__FadeIn  = 0x0;
         uint64_t C_Fader__FadeOut = 0x0;
         uint64_t C_Fader__Reset   = 0x0;
 
         // C_ShotManager
-        uint64_t C_ShotManager__GetInstance = 0x0;
+        uint64_t C_ShotManager__GetInstance     = 0x0;
         uint64_t C_ShotManager__CreateExplosion = 0x0;
         uint64_t C_ShotManager__CreateFire      = 0x0;
 
@@ -299,13 +306,13 @@ namespace SDK {
         uint64_t C_Explosion__Clear = 0x0;
 
         // Lua
-        uint64_t Lua__pcallAddr      = 0x0;
-        uint64_t Lua__loadbufferAddr = 0x0;
-        uint64_t Lua__tostringAddr   = 0x0;
-        uint64_t Lua__isstringAddr   = 0x0;
+        uint64_t Lua__pcall      = 0x0;
+        uint64_t Lua__loadbuffer = 0x0;
+        uint64_t Lua__tostring   = 0x0;
+        uint64_t Lua__isstring   = 0x0;
 
         // C_StreamMap
-        uint64_t C_StreamMap__CloseGame = 0x0;
+        uint64_t C_StreamMap__CloseGame    = 0x0;
         uint64_t C_StreamMap__CloseMission = 0x0;
         uint64_t C_StreamMap__ClosePart    = 0x0;
         uint64_t C_StreamMap__GetGame      = 0x0;
@@ -321,14 +328,18 @@ namespace SDK {
         // C_SysODB
         uint64_t C_SysODB__GetInstance = 0x0;
 
-        // C_MafiaDBS
-        uint64_t C_MafiaDBS__GetVehiclesDatabase = 0x0;
+        // C_MafiaDBs
+        uint64_t C_MafiaDBs__GetVehiclesDatabase = 0x0;
+        uint64_t C_MafiaDBs__GetTablesDatabase   = 0x0;
 
         // C_VehiclesDatabase
-        uint64_t C_VehiclesDatabase__GetVehiclesCount = 0x0;
+        uint64_t C_VehiclesDatabase__GetVehiclesCount  = 0x0;
         uint64_t C_VehiclesDatabase__GetVehicleByIndex = 0x0;
-        uint64_t C_VehiclesDatabase__GetVehicleByID = 0x0;
+        uint64_t C_VehiclesDatabase__GetVehicleByID    = 0x0;
         uint64_t C_VehiclesDatabase__GetVehicleByModel = 0x0;
+
+        // C_MenuSave
+        uint64_t C_MenuSave__OpenDebugLoadChapterString = 0x0;
 
         static void InitPatterns();
     };

--- a/code/client/src/sdk/ue/c_string.cpp
+++ b/code/client/src/sdk/ue/c_string.cpp
@@ -2,12 +2,10 @@
 
 #include "../patterns.h"
 
-#include <utils/hooking/hooking.h>
-
 namespace SDK {
     namespace ue {
         void C_String::SetString(const char *str) {
-            hook::this_call(gPatterns.C_String__SetStringAddr, this, str);
+            hook::this_call(gPatterns.C_String__SetString, this, str);
         }
     } // namespace ue
 } // namespace SDK

--- a/code/client/src/sdk/ue/game/camera/c_game_camera.cpp
+++ b/code/client/src/sdk/ue/game/camera/c_game_camera.cpp
@@ -1,12 +1,11 @@
 #include "c_game_camera.h"
 
-#include <utils/hooking/hooking.h>
 #include "../../../patterns.h"
 
 namespace SDK {
     namespace ue::game::camera {
         C_GameCamera *C_GameCamera::GetInstanceInternal() {
-            return hook::call<C_GameCamera *>(gPatterns.C_GameCamera__GetInstanceInternalAddr);
+            return hook::call<C_GameCamera *>(gPatterns.C_GameCamera__GetInstanceInternal);
         }
-    }
-}
+    } // namespace ue::game::camera
+} // namespace SDK

--- a/code/client/src/sdk/ue/game/humainai/c_character_controller.cpp
+++ b/code/client/src/sdk/ue/game/humainai/c_character_controller.cpp
@@ -2,7 +2,6 @@
 
 #include "c_character_state_handler_base_locomotion.h"
 
-#include <utils/hooking/hooking.h>
 #include "../../../entities/c_player_2.h"
 #include "../../../patterns.h"
 
@@ -118,4 +117,4 @@ namespace SDK {
             return hook::this_call<bool>(gPatterns.C_CharacterController__TriggerActorActionById, this, pActor, actorAction, a4, a5, a6);
         }
     } // namespace ue::game::humanai
-}
+} // namespace SDK

--- a/code/client/src/sdk/ue/game/humainai/c_character_state_handler.cpp
+++ b/code/client/src/sdk/ue/game/humainai/c_character_state_handler.cpp
@@ -1,9 +1,9 @@
 #include "c_character_state_handler.h"
 
-#include <utils/hooking/hooking.h>
+#include "../../../patterns.h"
+
 #include "../../../entities/c_entity.h"
 #include "../../../entities/c_human_2.h"
-#include "../../../patterns.h"
 
 #include "c_character_controller.h"
 
@@ -47,4 +47,4 @@ namespace SDK {
             }
         }
     } // namespace ue::game::humanai
-}
+} // namespace SDK

--- a/code/client/src/sdk/ue/game/human/c_behavior_character.cpp
+++ b/code/client/src/sdk/ue/game/human/c_behavior_character.cpp
@@ -1,6 +1,5 @@
 #include "c_behavior_character.h"
 
-#include <utils/hooking/hooking.h>
 #include "../../../patterns.h"
 
 namespace SDK {
@@ -9,4 +8,4 @@ namespace SDK {
             hook::this_call<void>(gPatterns.C_BehaviorCharacter__SetWAnimVariable_float, this, id, value);
         }
     } // namespace ue::game::human
-}
+} // namespace SDK

--- a/code/client/src/sdk/ue/game/shotmanager/c_explosion.cpp
+++ b/code/client/src/sdk/ue/game/shotmanager/c_explosion.cpp
@@ -1,6 +1,5 @@
 #include "c_explosion.h"
 
-#include <utils/hooking/hooking.h>
 #include "../../../patterns.h"
 
 namespace SDK {
@@ -8,5 +7,5 @@ namespace SDK {
         void C_Explosion::Clear() {
             hook::this_call(gPatterns.C_Explosion__Clear, this);
         }
-    }
-}
+    } // namespace ue::game::shotmanager
+} // namespace SDK

--- a/code/client/src/sdk/ue/game/shotmanager/c_fire.cpp
+++ b/code/client/src/sdk/ue/game/shotmanager/c_fire.cpp
@@ -1,6 +1,5 @@
 #include "c_fire.h"
 
-#include <utils/hooking/hooking.h>
 #include "../../../patterns.h"
 
 namespace SDK {
@@ -8,5 +7,5 @@ namespace SDK {
         void C_Fire::Clear() {
             hook::this_call<void>(gPatterns.C_Fire__Clear, this);
         }
-    }
-}
+    } // namespace ue::game::shotmanager
+} // namespace SDK

--- a/code/client/src/sdk/ue/game/shotmanager/c_shot_manager.cpp
+++ b/code/client/src/sdk/ue/game/shotmanager/c_shot_manager.cpp
@@ -1,20 +1,19 @@
 #include "c_shot_manager.h"
 
-#include <utils/hooking/hooking.h>
 #include "../../../patterns.h"
 
 namespace SDK {
     namespace ue::game::shotmanager {
         C_ShotManager *C_ShotManager::GetInstance() {
-            return hook::call<C_ShotManager*>(gPatterns.C_ShotManager__GetInstance);
+            return hook::call<C_ShotManager *>(gPatterns.C_ShotManager__GetInstance);
         }
 
-        C_Fire* C_ShotManager::CreateFire(S_FireInit const* params) {
+        C_Fire *C_ShotManager::CreateFire(S_FireInit const *params) {
             return hook::this_call<C_Fire *>(gPatterns.C_ShotManager__CreateFire, this, params);
         }
 
-        C_Explosion* C_ShotManager::CreateExplosion(S_ExplosionInit const* params) {
+        C_Explosion *C_ShotManager::CreateExplosion(S_ExplosionInit const *params) {
             return hook::this_call<C_Explosion *>(gPatterns.C_ShotManager__CreateExplosion, this, params);
         }
-    }
-}
+    } // namespace ue::game::shotmanager
+} // namespace SDK

--- a/code/client/src/sdk/ue/game/traffic/c_human_spawner.cpp
+++ b/code/client/src/sdk/ue/game/traffic/c_human_spawner.cpp
@@ -2,21 +2,18 @@
 
 #include "../../../patterns.h"
 
-#include <utils/hooking/hooking.h>
-
 namespace SDK {
     namespace ue::game::traffic {
         C_HumanSpawner::C_HumanSpawner(const ue::sys::utils::C_HashName &profile, int unk): C_ProfileSpawner(SetupDefaultArchetypeObject(), profile, unk) {
-            vftable = gPatterns.C_HumanSpawner__C_HumanSpawnerVtblAddr;
+            vftable = gPatterns.C_HumanSpawner__C_HumanSpawnerVtbl;
         }
 
         C_HumanSpawner::~C_HumanSpawner() {
-            vftable = gPatterns.C_HumanSpawner__C_HumanSpawnerVtblAddr;
+            vftable = gPatterns.C_HumanSpawner__C_HumanSpawnerVtbl;
         }
 
         ue::C_WeakPtr<ue::sys::core::C_SceneObject> C_HumanSpawner::SetupDefaultArchetypeObject() {
-            return (
-                *(ue::C_WeakPtr<ue::sys::core::C_SceneObject>(__thiscall *)(ue::game::traffic::C_HumanSpawner *))gPatterns.C_HumanSpawner__SetupDefaultArchetypeObjectAddr)(this);
+            return (*(ue::C_WeakPtr<ue::sys::core::C_SceneObject>(__thiscall *)(ue::game::traffic::C_HumanSpawner *))gPatterns.C_HumanSpawner__SetupDefaultArchetypeObject)(this);
         }
     } // namespace ue::game::traffic
 } // namespace SDK

--- a/code/client/src/sdk/ue/game/traffic/c_profile_spawner.cpp
+++ b/code/client/src/sdk/ue/game/traffic/c_profile_spawner.cpp
@@ -1,31 +1,28 @@
 #include "c_profile_spawner.h"
 
-#include <utils/hooking/hooking.h>
-#include "../../../patterns.h"
 #include "../../../c_ie.h"
+#include "../../../patterns.h"
 
 namespace SDK {
     namespace ue::game::traffic {
         C_ProfileSpawner::C_ProfileSpawner(ue::C_WeakPtr<ue::sys::core::C_SceneObject> sceneObject, const ue::sys::utils::C_HashName &profile, int unk1, unsigned long unk2) {
-            (*(void(__thiscall *)(C_ProfileSpawner *, ue::C_WeakPtr<ue::sys::core::C_SceneObject> &, const ue::sys::utils::C_HashName &, int,
-                unsigned long))gPatterns.C_ProfileSpawner__C_ProfileSpawnerAddr)(this, sceneObject, profile, unk1, unk2);
+            (*(void(__thiscall *)(C_ProfileSpawner *, ue::C_WeakPtr<ue::sys::core::C_SceneObject> &, const ue::sys::utils::C_HashName &, int, unsigned long))gPatterns.C_ProfileSpawner__C_ProfileSpawner)(this, sceneObject, profile, unk1, unk2);
         }
 
         C_ProfileSpawner::~C_ProfileSpawner() {
-            hook::this_call<void>(gPatterns.C_ProfileSpawner__C_ProfileSpawnerDctorAddr, this);
+            hook::this_call<void>(gPatterns.C_ProfileSpawner__C_ProfileSpawnerDctor, this);
         }
 
         bool C_ProfileSpawner::IsSpawnProfileLoaded() {
-            return hook::this_call<bool>(gPatterns.C_ProfileSpawner__IsSpawnProfileLoadedAddr, this);
+            return hook::this_call<bool>(gPatterns.C_ProfileSpawner__IsSpawnProfileLoaded, this);
         }
 
         void C_ProfileSpawner::CreateActor(ue::C_WeakPtr<ue::sys::core::C_SceneObject> &SceneObject, C_Actor *&pActor, void *unk1, unsigned int unk2, unsigned int unk3) {
-            (*(void(__thiscall *)(C_ProfileSpawner *, ue::C_WeakPtr<ue::sys::core::C_SceneObject> &, C_Actor *&, void *, unsigned int,
-                unsigned int))gPatterns.C_ProfileSpawner__CreateActorAddr)(this, SceneObject, pActor, unk1, unk2, unk3);
+            (*(void(__thiscall *)(C_ProfileSpawner *, ue::C_WeakPtr<ue::sys::core::C_SceneObject> &, C_Actor *&, void *, unsigned int, unsigned int))gPatterns.C_ProfileSpawner__CreateActor)(this, SceneObject, pActor, unk1, unk2, unk3);
         }
 
         void C_ProfileSpawner::ReturnObject(ue::sys::core::C_SceneObject *pSceneObject) {
-            hook::this_call<void>(gPatterns.C_ProfileSpawner__ReturnObjectAddr, this, pSceneObject);
+            hook::this_call<void>(gPatterns.C_ProfileSpawner__ReturnObject, this, pSceneObject);
         }
 
         void *C_ProfileSpawner::operator new(size_t size) {

--- a/code/client/src/sdk/ue/gfx/environmenteffects/c_gfx_environment_effects.cpp
+++ b/code/client/src/sdk/ue/gfx/environmenteffects/c_gfx_environment_effects.cpp
@@ -9,7 +9,7 @@ namespace SDK {
         }
 
         C_GfxEnvironmentEffects *C_GfxEnvironmentEffects::GetInstance() {
-            return *reinterpret_cast<C_GfxEnvironmentEffects **>(gPatterns.C_GfxEnvironmentEffects_Instance);
+            return *reinterpret_cast<C_GfxEnvironmentEffects **>(gPatterns.C_GfxEnvironmentEffects__Instance);
         }
     } // namespace ue::gfx::environmenteffects
 }

--- a/code/client/src/sdk/ue/gfx/environmenteffects/c_weather_manager_2.cpp
+++ b/code/client/src/sdk/ue/gfx/environmenteffects/c_weather_manager_2.cpp
@@ -1,25 +1,23 @@
 #include "c_weather_manager_2.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../../patterns.h"
 
 namespace SDK {
     namespace ue::gfx::environmenteffects {
         float C_WeatherManager2::GetDayTimeHours() {
-            return hook::this_call<float>(gPatterns.C_WeatherManager2__GetDayTimeHoursAddr, this);
+            return hook::this_call<float>(gPatterns.C_WeatherManager2__GetDayTimeHours, this);
         }
 
         float C_WeatherManager2::GetDayTimeRel() {
-            return hook::this_call<float>(gPatterns.C_WeatherManager2__GetDayTimeRelAddr, this);
+            return hook::this_call<float>(gPatterns.C_WeatherManager2__GetDayTimeRel, this);
         }
 
         void C_WeatherManager2::SetDayTimeHours(float time) {
-            hook::this_call<float>(gPatterns.C_WeatherManager2__SetDayTimeHoursAddr, this, time);
+            hook::this_call<float>(gPatterns.C_WeatherManager2__SetDayTimeHours, this, time);
         }
 
         void C_WeatherManager2::SetDayTimeRel(float time) {
-            hook::this_call<float>(gPatterns.C_WeatherManager2__SetDayTimeRelAddr, this, time);
+            hook::this_call<float>(gPatterns.C_WeatherManager2__SetDayTimeRel, this, time);
         }
 
         void C_WeatherManager2::SetDayTimeSec(float time) {
@@ -28,7 +26,7 @@ namespace SDK {
         }
 
         void C_WeatherManager2::SetWeatherSet(ue::C_String const &preset, float time) {
-            hook::this_call(gPatterns.C_WeatherManager2__SetWeatherSetAddr, this, preset, time);
+            hook::this_call(gPatterns.C_WeatherManager2__SetWeatherSet, this, preset, time);
         }
     } // namespace ue::gfx::environmenteffects
-}
+} // namespace SDK

--- a/code/client/src/sdk/ue/sys/core/c_scene_object.cpp
+++ b/code/client/src/sdk/ue/sys/core/c_scene_object.cpp
@@ -1,7 +1,5 @@
 #include "c_scene_object.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../../../patterns.h"
 
 namespace SDK {
@@ -11,7 +9,7 @@ namespace SDK {
         }
 
         void C_SceneObject::SetTransform(const ue::sys::math::C_Matrix &transform, E_TransformChangeType changeType) {
-            hook::this_call(gPatterns.C_SceneObject__SetTransformAddr, this, transform, changeType);
+            hook::this_call(gPatterns.C_SceneObject__SetTransform, this, transform, changeType);
         }
     } // namespace ue::sys::core
 } // namespace SDK

--- a/code/client/src/sdk/ue/sys/core/i_core.cpp
+++ b/code/client/src/sdk/ue/sys/core/i_core.cpp
@@ -2,8 +2,6 @@
 
 #include "../../../patterns.h"
 
-#include <utils/hooking/hooking.h>
-
 namespace SDK {
     namespace ue::sys::core {
         C_Core *I_Core::GetInstance() {

--- a/code/client/src/sdk/ue/sys/filesystem/c_virtual_file_system_cache.h
+++ b/code/client/src/sdk/ue/sys/filesystem/c_virtual_file_system_cache.h
@@ -3,13 +3,11 @@
 #include "../../../patterns.h"
 #include "c_virtual_file_system.h"
 
-#include <utils/hooking/hooking.h>
-
 namespace SDK::ue::sys::filesystem {
-    class C_VirtualFileSystemCache : public C_VirtualFileSystem {
+    class C_VirtualFileSystemCache: public C_VirtualFileSystem {
       public:
-        static C_VirtualFileSystemCache* GetInstance() {
+        static C_VirtualFileSystemCache *GetInstance() {
             return hook::this_call<C_VirtualFileSystemCache *>(gPatterns.I_VirtualFileSystemCache__GetInstance);
         }
     };
-}
+} // namespace SDK::ue::sys::filesystem

--- a/code/client/src/sdk/ue/sys/math/c_matrix.cpp
+++ b/code/client/src/sdk/ue/sys/math/c_matrix.cpp
@@ -1,28 +1,28 @@
 #include "c_matrix.h"
-#include <utils/hooking/hooking.h>
+
 #include "../../../patterns.h"
 #include "c_quat.h"
 
 namespace SDK {
     namespace ue::sys::math {
         void C_Matrix::SetDir(C_Vector const &arg1, C_Vector const &arg2) {
-            hook::this_call(gPatterns.C_Matrix__SetDir2Addr, this, arg1, arg2);
+            hook::this_call(gPatterns.C_Matrix__SetDir2, this, arg1, arg2);
         }
 
         void C_Matrix::SetDir(C_Vector const &arg) {
-            hook::this_call(gPatterns.C_Matrix__SetDirAddr, this, arg);
+            hook::this_call(gPatterns.C_Matrix__SetDir, this, arg);
         }
 
         void C_Matrix::SetDir3(C_Vector const &arg) {
-            hook::this_call(gPatterns.C_Matrix__SetDir3Addr, this, arg);
+            hook::this_call(gPatterns.C_Matrix__SetDir3, this, arg);
         }
 
         void C_Matrix::SetRot(C_Quat const &rot) {
-            hook::this_call(gPatterns.C_Matrix__SetRotAddr, this, rot);
+            hook::this_call(gPatterns.C_Matrix__SetRot, this, rot);
         }
 
         void C_Matrix::SetRotEuler(float pitch, float yaw, float roll) {
-            hook::this_call(gPatterns.C_Matrix__SetRotEulerAddr, this, pitch, yaw, roll);
+            hook::this_call(gPatterns.C_Matrix__SetRotEuler, this, pitch, yaw, roll);
         }
     }; // namespace ue::sys::math
 } // namespace SDK

--- a/code/client/src/sdk/ue/sys/math/c_quat.cpp
+++ b/code/client/src/sdk/ue/sys/math/c_quat.cpp
@@ -3,7 +3,7 @@
 #include "utils.hpp"
 
 #include <cmath>
-#include <utils/hooking/hooking.h>
+
 #include "../../../patterns.h"
 
 namespace SDK {
@@ -85,8 +85,7 @@ namespace SDK {
         }
 
         C_Quat C_Quat::operator*(const C_Quat &rhs) const {
-            return {(rhs.w * x) + (rhs.x * w) + (rhs.y * z) - (rhs.z * y), (rhs.w * y) - (rhs.x * z) + (rhs.y * w) + (rhs.z * x),
-                    (rhs.w * z) + (rhs.x * y) - (rhs.y * x) + (rhs.z * w), (rhs.w * w) - (rhs.x * x) - (rhs.y * y) - (rhs.z * z)};
+            return {(rhs.w * x) + (rhs.x * w) + (rhs.y * z) - (rhs.z * y), (rhs.w * y) - (rhs.x * z) + (rhs.y * w) + (rhs.z * x), (rhs.w * z) + (rhs.x * y) - (rhs.y * x) + (rhs.z * w), (rhs.w * w) - (rhs.x * x) - (rhs.y * y) - (rhs.z * z)};
         }
 
         C_Quat C_Quat::operator*(float rhs) const {

--- a/code/client/src/sdk/ue/sys/utils/c_hash_name.h
+++ b/code/client/src/sdk/ue/sys/utils/c_hash_name.h
@@ -3,7 +3,6 @@
 #include "../../../patterns.h"
 
 #include <stdint.h>
-#include <utils/hooking/hooking.h>
 
 namespace SDK {
     namespace ue::sys::utils {
@@ -16,13 +15,11 @@ namespace SDK {
             C_HashName(uint64_t val): value(val) {}
 
             static uint64_t ComputeHash(const char *str, bool *pSuccess = nullptr) {
-                const auto C_HashName__ComputeHashAddr = reinterpret_cast<uint64_t>(hook::pattern("48 89 74 24 ? 41 56 48 83 EC ? 4C 8B F2 48 8B F1 48 85 C9").get_first());
-                return hook::call<uint64_t>(C_HashName__ComputeHashAddr, str, pSuccess);
+                return hook::call<uint64_t>(gPatterns.C_HashName__ComputeHash, str, pSuccess);
             }
 
             uint32_t SetName(const char *str) {
-                const auto C_HashName__SetNameAddr = reinterpret_cast<uint64_t>(hook::pattern("44 0F B6 11 4C 8B C2").get_first());
-                return hook::this_call<uint32_t>(C_HashName__SetNameAddr, this, str);
+                return hook::this_call<uint32_t>(gPatterns.C_HashName__ComputeHash, this, str);
             }
 
             // Conversion Operator

--- a/code/client/src/sdk/wrappers/c_human_2_car_wrapper.cpp
+++ b/code/client/src/sdk/wrappers/c_human_2_car_wrapper.cpp
@@ -1,7 +1,5 @@
 #include "c_human_2_car_wrapper.h"
 
-#include <utils/hooking/hooking.h>
-
 #include "../patterns.h"
 
 namespace SDK {
@@ -12,4 +10,4 @@ namespace SDK {
     unsigned int C_Human2CarWrapper::GetSeatID(C_Actor *pActor) {
         return hook::this_call<unsigned int>(gPatterns.C_Human2CarWrapper__GetSeatID, this, pActor);
     }
-}
+} // namespace SDK


### PR DESCRIPTION
### Summary
- Remove unwanted `Addr` suffix on some names
- Use `hook::get_pattern()` instead of `hook::pattern().get_first()`
- Remove useless `utils/hooking/hooking.h` import (already imported in `pattern.h`)
- Moving patterns to dedicated file if it was not there
- Group by name and alphabetical order
- Remove absolute import in sdk files
- Remove sdk relative import in project (outside sdk folder)
- Always use `__` (2 underscores) between class name and attributes