### PR TITLE
Fix player direction when teleported

### DIFF
--- a/code/client/src/core/ui/entity_browser.cpp
+++ b/code/client/src/core/ui/entity_browser.cpp
@@ -161,7 +161,7 @@ namespace MafiaMP::Core::UI {
                         auto entityPos = inspectedEntity->GetPos();
                         auto entityDir = inspectedEntity->GetDir();
 
-                        if (ImGui::DragFloat3("Pos", (float *)&entityPos, 0.1f, -2000.0f, 2000.0f)) {
+                        if (ImGui::DragFloat3("Pos", (float *)&entityPos, 0.1f, -4500.0f, 4500.0f)) {
                             inspectedEntity->SetPos(entityPos);
                         }
 

--- a/code/client/src/core/ui/player_debug.cpp
+++ b/code/client/src/core/ui/player_debug.cpp
@@ -24,7 +24,7 @@ namespace MafiaMP::Core::UI {
         ImGui::Begin("Player debug", &_visible);
 
         auto position = pActivePlayer->GetPos();
-        if (ImGui::DragFloat3("Pos", (float *)&position, 0.1f, -2000.0f, 2000.0f)) {
+        if (ImGui::DragFloat3("Pos", (float *)&position, 0.1f, -4500.0f, 4500.0f)) {
             pActivePlayer->SetPos(position);
         }
 

--- a/code/client/src/core/ui/vehicle_debug.cpp
+++ b/code/client/src/core/ui/vehicle_debug.cpp
@@ -23,7 +23,7 @@ namespace MafiaMP::Core::UI {
             auto currentVehicle = currentCar->GetVehicle();
 
             auto position = currentCar->GetPos();
-            if (ImGui::DragFloat3("Pos", (float *)&position, 0.1f, -2000.0f, 2000.0f)) {
+            if (ImGui::DragFloat3("Pos", (float *)&position, 0.1f, -4500.0f, 4500.0f)) {
                 currentCar->SetPos(position);
             }
 

--- a/gamemode/index.js
+++ b/gamemode/index.js
@@ -275,7 +275,7 @@ const weatherSets = ["mm_030_molotov_cp_010_cine", "mm_150_boat_cp_010", "mm_210
 
 const SPAWN_POINT = {
     pos: sdk.Vector3(-985.871, -299.401, 2.1),
-    rot: sdk.Quaternion(0.301, 0.0, 0.0, -0.954),
+    rot: sdk.Quaternion(0.291, 0, 0, -0.957),
 };
 
 sdk.on("gamemodeLoaded", () => {
@@ -417,8 +417,15 @@ RegisterChatCommand("pos", (player, message, command, args) => {
             .toFixed(3)
             .replace(/\.?0+$/, "");
 
-    player.sendChat(`[SERVER] Position: ${parse(pos.x)}, ${parse(pos.y)}, ${parse(pos.z)}`);
-    player.sendChat(`[SERVER] Rotation: ${parse(rot.w)}, ${parse(rot.x)}, ${parse(rot.y)}, ${parse(rot.z)}`);
+    const posParsedMessage = `${parse(pos.x)}, ${parse(pos.y)}, ${parse(pos.z)}`
+    const rotParsedMessage = `${parse(rot.w)}, ${parse(rot.x)}, ${parse(rot.y)}, ${parse(rot.z)}`
+
+    player.sendChat(`[SERVER] Position: ${posParsedMessage}`);
+    player.sendChat(`[SERVER] Rotation: ${rotParsedMessage}`);
+
+    // Log in console for easy copy-paste
+    console.log(`[GAMEMODE] Player Position: ${posParsedMessage}`);
+    console.log(`[GAMEMODE] Player Rotation: ${rotParsedMessage}`);
 });
 
 RegisterChatCommand("veh", (player, message, command, args) => {


### PR DESCRIPTION
Fix https://github.com/MafiaHub/MafiaMP/issues/45

I went for the solution of using rotation quaternion to calculate the direction.

This will do the job until [we find a way to preload the world](https://github.com/MafiaHub/MafiaMP/issues/62).

Also I fixed the values ​​for the positions in the debug UIs to cover the entire map.