### PR TITLE
Reverse more WeatherManager2 stuffs

### DIFF
--- a/code/client/src/sdk/patterns.cpp
+++ b/code/client/src/sdk/patterns.cpp
@@ -420,12 +420,18 @@ namespace SDK {
         gPatterns.C_WAnimPlaybackManager__PlayState = hook::get_opcode_address("E8 ? ? ? ? 4C 39 7F 50");
 
         // C_WeatherManager2
-        gPatterns.C_WeatherManager2__GetDayTimeHours = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? F3 0F 10 81 ? ? ? ?"));
-        gPatterns.C_WeatherManager2__GetDayTimeRel   = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? F3 0F 59 05 ? ? ? ? C3 ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? 48 8B 41 ?"));
-        gPatterns.C_WeatherManager2__SetDayTimeHours = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 59 0D ? ? ? ? 0F 57 DB F3 0F 10 15 ? ? ? ? 0F 28 C1 F3 0F 5C C2 0F 2F C3 73 ? 0F 28 D1 F3 0F 10 0D ? ? ? ? 0F 28 C1 F3 "
-                                                                                                    "0F 5C C2 0F 2F C3 72 ? F3 0F 11 89 ? ? ? ? C3 F3 0F 11 91 ? ? ? ? C3 ? ? ? ? ? ? ? ? F3 0F 59 0D ? ? ? ?"));
-        gPatterns.C_WeatherManager2__SetDayTimeRel   = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 59 0D ? ? ? ? F3 0F 11 49 ? C3 ? ? F3 0F 59 0D ? ? ? ? 0F 57 DB"));
-        gPatterns.C_WeatherManager2__SetWeatherSet   = hook::get_opcode_address("E8 ? ? ? ? 48 8D 4F ? E8 ? ? ? ? E9 ? ? ? ? E8 ? ? ? ?");
+        gPatterns.C_WeatherManager2__EnableTimeFlow              = reinterpret_cast<uint64_t>(hook::get_pattern("88 91 ? ? ? ? C6 81 ? ? ? ? ? C6 81 ? ? ? ? ? C3"));
+        gPatterns.C_WeatherManager2__GetDayTimeHours             = hook::get_opcode_address("E8 ? ? ? ? 48 8B 4B 38 33 C0");
+        gPatterns.C_WeatherManager2__GetDayTimeRel               = hook::get_opcode_address("E8 ? ? ? ? F3 0F 11 43 ? 48 8D 54 24 ?");
+        gPatterns.C_WeatherManager2__GetDefaultTimeFlowSpeedMult = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? C3 CC CC CC CC CC CC CC 8B 05 ? ? ? ?"));
+        gPatterns.C_WeatherManager2__GetUserTimeFlowSpeedMult    = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 10 81 ? ? ? ? C3 CC CC CC CC CC CC CC 41 83 F8 04"));
+        gPatterns.C_WeatherManager2__IsTimeFlowEnabled = reinterpret_cast<uint64_t>(hook::get_pattern("0F B6 81 ? ? ? ? C3 CC CC CC CC CC CC CC CC 32 C0 C3 CC CC CC CC CC CC CC CC CC CC CC CC CC 32 C0 C3 CC CC CC CC CC CC CC CC CC CC CC CC CC 32 C0 C3 CC CC CC CC CC CC CC CC CC "
+                                                                                                      "CC CC CC CC 32 C0 C3 CC CC CC CC CC CC CC CC CC CC CC CC CC 32 C0 C3 CC CC CC CC CC CC CC CC CC CC CC CC CC 32 C0 C3 CC CC CC CC CC CC CC CC CC CC CC CC CC B0 01"));
+        gPatterns.C_WeatherManager2__SetDayTimeHours   = hook::get_opcode_address("E8 ? ? ? ? 48 83 C4 30 5F 5E 5B C3 CC CC CC CC CC CC CC CC CC 48 83 EC 38");
+        gPatterns.C_WeatherManager2__SetDayTimeSec     = hook::get_opcode_address("E9 ? ? ? ? 8B 47 18 89 44 24 40");
+        gPatterns.C_WeatherManager2__SetDefaultTimeFlowSpeedMult = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 11 89 ? ? ? ? C3 CC CC CC CC CC CC CC F3 0F 11 89 ? ? ? ? C3 CC CC CC CC CC CC CC F3 0F 59 0D ? ? ? ?"));
+        gPatterns.C_WeatherManager2__SetUserTimeFlowSpeedMult    = reinterpret_cast<uint64_t>(hook::get_pattern("F3 0F 11 89 ? ? ? ? C3 CC CC CC CC CC CC CC 83 FA 04"));
+        gPatterns.C_WeatherManager2__SetWeatherSet               = hook::get_opcode_address("E8 ? ? ? ? 48 83 7C 24 ? ? 0F 28 74 24 ?");
 
         // I_Core
         gPatterns.I_Core__GetInstance = hook::get_opcode_address("E8 ? ? ? ? 4C 8B 40 68");

--- a/code/client/src/sdk/patterns.h
+++ b/code/client/src/sdk/patterns.h
@@ -108,7 +108,6 @@ namespace SDK {
 
         // C_GameAudioModule
         uint64_t C_GameAudioModule__GetAudioModule    = 0x0;
-
         uint64_t C_GameAudioModule__SetCutsceneVolume = 0x0;
         uint64_t C_GameAudioModule__SetDialogueVolume = 0x0;
         uint64_t C_GameAudioModule__SetDynamicRange   = 0x0;
@@ -354,11 +353,17 @@ namespace SDK {
         uint64_t C_WAnimPlaybackManager__PlayState = 0x0;
 
         // C_WeatherManager2
-        uint64_t C_WeatherManager2__GetDayTimeHours = 0x0;
-        uint64_t C_WeatherManager2__GetDayTimeRel   = 0x0;
-        uint64_t C_WeatherManager2__SetDayTimeHours = 0x0;
-        uint64_t C_WeatherManager2__SetDayTimeRel   = 0x0;
-        uint64_t C_WeatherManager2__SetWeatherSet   = 0x0;
+        uint64_t C_WeatherManager2__EnableTimeFlow              = 0x0;
+        uint64_t C_WeatherManager2__GetDayTimeHours             = 0x0;
+        uint64_t C_WeatherManager2__GetDayTimeRel               = 0x0;
+        uint64_t C_WeatherManager2__GetDefaultTimeFlowSpeedMult = 0x0;
+        uint64_t C_WeatherManager2__GetUserTimeFlowSpeedMult    = 0x0;
+        uint64_t C_WeatherManager2__IsTimeFlowEnabled           = 0x0;
+        uint64_t C_WeatherManager2__SetDayTimeHours             = 0x0;
+        uint64_t C_WeatherManager2__SetDayTimeSec               = 0x0;
+        uint64_t C_WeatherManager2__SetDefaultTimeFlowSpeedMult = 0x0;
+        uint64_t C_WeatherManager2__SetUserTimeFlowSpeedMult    = 0x0;
+        uint64_t C_WeatherManager2__SetWeatherSet               = 0x0;
 
         // I_Core
         uint64_t I_Core__GetInstance = 0x0;

--- a/code/client/src/sdk/ue/gfx/environmenteffects/c_weather_manager_2.cpp
+++ b/code/client/src/sdk/ue/gfx/environmenteffects/c_weather_manager_2.cpp
@@ -4,6 +4,14 @@
 
 namespace SDK {
     namespace ue::gfx::environmenteffects {
+        /**
+         * When false, dynamic weather sets will not change if you change the time.
+         * You should set SetDefaultTimeFlowSpeedMult or SetUserTimeFlowSpeedMult to 0 to disable time flow.
+         */
+        void C_WeatherManager2::EnableTimeFlow(bool enable) {
+            return hook::this_call<void>(gPatterns.C_WeatherManager2__EnableTimeFlow, this, enable);
+        }
+
         float C_WeatherManager2::GetDayTimeHours() {
             return hook::this_call<float>(gPatterns.C_WeatherManager2__GetDayTimeHours, this);
         }
@@ -12,21 +20,40 @@ namespace SDK {
             return hook::this_call<float>(gPatterns.C_WeatherManager2__GetDayTimeRel, this);
         }
 
-        void C_WeatherManager2::SetDayTimeHours(float time) {
-            hook::this_call<float>(gPatterns.C_WeatherManager2__SetDayTimeHours, this, time);
+        float C_WeatherManager2::GetDefaultTimeFlowSpeedMult() {
+            return hook::this_call<float>(gPatterns.C_WeatherManager2__GetDefaultTimeFlowSpeedMult, this);
         }
 
-        void C_WeatherManager2::SetDayTimeRel(float time) {
-            hook::this_call<float>(gPatterns.C_WeatherManager2__SetDayTimeRel, this, time);
+        float C_WeatherManager2::GetUserTimeFlowSpeedMult() {
+            return hook::this_call<float>(gPatterns.C_WeatherManager2__GetUserTimeFlowSpeedMult, this);
         }
 
-        void C_WeatherManager2::SetDayTimeSec(float time) {
-            // const auto C_WeatherManager2__SetDayTimeSecAddr = reinterpret_cast<uint64_t>(hook::pattern("").first());
-            // hook::this_call<float>(0x0000001421076A0, this, time);
+        bool C_WeatherManager2::IsTimeFlowEnabled() {
+            return hook::this_call<bool>(gPatterns.C_WeatherManager2__IsTimeFlowEnabled, this);
         }
 
-        void C_WeatherManager2::SetWeatherSet(ue::C_String const &preset, float time) {
-            hook::this_call(gPatterns.C_WeatherManager2__SetWeatherSet, this, preset, time);
+        void C_WeatherManager2::SetDayTimeHours(float hour) {
+            hook::this_call<void>(gPatterns.C_WeatherManager2__SetDayTimeHours, this, hour);
+        }
+
+        void C_WeatherManager2::SetDayTimeSec(float seconds) {
+            hook::this_call(gPatterns.C_WeatherManager2__SetDayTimeSec, this, seconds);
+        }
+
+        void C_WeatherManager2::SetDefaultTimeFlowSpeedMult(float speedMult) {
+            return hook::this_call<void>(gPatterns.C_WeatherManager2__SetDefaultTimeFlowSpeedMult, this, speedMult);
+        }
+
+        void C_WeatherManager2::SetUserTimeFlowSpeedMult(float speedMult) {
+            return hook::this_call<void>(gPatterns.C_WeatherManager2__SetUserTimeFlowSpeedMult, this, speedMult);
+        }
+
+        /**
+         * @param weatherSetName Name of the weather set
+         * @param transitionSpeed Speed ​​at which we move from one weather to another. 0 for immediately.
+         */
+        void C_WeatherManager2::SetWeatherSet(ue::C_String const &weatherSetName, float transitionSpeed) {
+            hook::this_call(gPatterns.C_WeatherManager2__SetWeatherSet, this, weatherSetName, transitionSpeed);
         }
     } // namespace ue::gfx::environmenteffects
 } // namespace SDK

--- a/code/client/src/sdk/ue/gfx/environmenteffects/c_weather_manager_2.cpp
+++ b/code/client/src/sdk/ue/gfx/environmenteffects/c_weather_manager_2.cpp
@@ -9,7 +9,7 @@ namespace SDK {
          * You should set SetDefaultTimeFlowSpeedMult or SetUserTimeFlowSpeedMult to 0 to disable time flow.
          */
         void C_WeatherManager2::EnableTimeFlow(bool enable) {
-            return hook::this_call<void>(gPatterns.C_WeatherManager2__EnableTimeFlow, this, enable);
+            hook::this_call<void>(gPatterns.C_WeatherManager2__EnableTimeFlow, this, enable);
         }
 
         float C_WeatherManager2::GetDayTimeHours() {
@@ -37,15 +37,15 @@ namespace SDK {
         }
 
         void C_WeatherManager2::SetDayTimeSec(float seconds) {
-            hook::this_call(gPatterns.C_WeatherManager2__SetDayTimeSec, this, seconds);
+            hook::this_call<void>(gPatterns.C_WeatherManager2__SetDayTimeSec, this, seconds);
         }
 
         void C_WeatherManager2::SetDefaultTimeFlowSpeedMult(float speedMult) {
-            return hook::this_call<void>(gPatterns.C_WeatherManager2__SetDefaultTimeFlowSpeedMult, this, speedMult);
+            hook::this_call<void>(gPatterns.C_WeatherManager2__SetDefaultTimeFlowSpeedMult, this, speedMult);
         }
 
         void C_WeatherManager2::SetUserTimeFlowSpeedMult(float speedMult) {
-            return hook::this_call<void>(gPatterns.C_WeatherManager2__SetUserTimeFlowSpeedMult, this, speedMult);
+            hook::this_call<void>(gPatterns.C_WeatherManager2__SetUserTimeFlowSpeedMult, this, speedMult);
         }
 
         /**
@@ -53,7 +53,7 @@ namespace SDK {
          * @param transitionSpeed Speed ​​at which we move from one weather to another. 0 for immediately.
          */
         void C_WeatherManager2::SetWeatherSet(ue::C_String const &weatherSetName, float transitionSpeed) {
-            hook::this_call(gPatterns.C_WeatherManager2__SetWeatherSet, this, weatherSetName, transitionSpeed);
+            hook::this_call<void>(gPatterns.C_WeatherManager2__SetWeatherSet, this, weatherSetName, transitionSpeed);
         }
     } // namespace ue::gfx::environmenteffects
 } // namespace SDK

--- a/code/client/src/sdk/ue/gfx/environmenteffects/c_weather_manager_2.h
+++ b/code/client/src/sdk/ue/gfx/environmenteffects/c_weather_manager_2.h
@@ -6,13 +6,17 @@ namespace SDK {
     namespace ue::gfx::environmenteffects {
         class C_WeatherManager2 {
           public:
+            void EnableTimeFlow(bool);
             float GetDayTimeHours();
             float GetDayTimeRel();
-
+            float GetDefaultTimeFlowSpeedMult();
+            float GetUserTimeFlowSpeedMult();
+            bool IsTimeFlowEnabled();
             void SetDayTimeHours(float);
-            void SetDayTimeRel(float);
             void SetDayTimeSec(float);
+            void SetDefaultTimeFlowSpeedMult(float);
+            void SetUserTimeFlowSpeedMult(float);
             void SetWeatherSet(ue::C_String const &, float);
         };
     } // namespace ue::gfx::environmenteffects
-}
+} // namespace SDK

--- a/code/server/src/core/server.cpp
+++ b/code/server/src/core/server.cpp
@@ -30,7 +30,7 @@ namespace MafiaMP {
 
         // Setup specific components - default values
         auto weather             = GetWorldEngine()->GetWorld()->get_mut<Core::Modules::Environment::Weather>();
-        weather->_weatherSetName = "_default_game"; // This is the default given by the game
+        weather->_weatherSetName = "_default_game";
         weather->_dayTimeHours   = 11.0f;
     }
 
@@ -109,7 +109,7 @@ namespace MafiaMP {
                 Scripting::Chat::EventChatMessage(ent, text);
             }
         });
-        
+
         // test until we do it via nodejs builtins
         net->RegisterGameRPC<Shared::RPC::HumanChangeSkin>([this](SLNet::RakNetGUID guid, Shared::RPC::HumanChangeSkin *msg) {
             if (!msg->Valid())

--- a/code/server/src/core/server.cpp
+++ b/code/server/src/core/server.cpp
@@ -30,7 +30,7 @@ namespace MafiaMP {
 
         // Setup specific components - default values
         auto weather             = GetWorldEngine()->GetWorld()->get_mut<Core::Modules::Environment::Weather>();
-        weather->_weatherSetName = "mm_110_omerta_cp_010_cs_cs_park";
+        weather->_weatherSetName = "_default_game"; // This is the default given by the game
         weather->_dayTimeHours   = 11.0f;
     }
 


### PR DESCRIPTION
- Remove C_WeatherManager2::SetDayTimeRel 
The pattern was wrong, it's `ue::gfx::environmenteffects::C_ExpressionKeyframer::SetCycleTimeH` actually
Could be `sub_142107770 `or `sub_1506A65B0` but their patterns cause crash.


--- 

- Part of https://github.com/MafiaHub/MafiaMP/issues/43

---

- Disable time flow will be in a separate PR
- WordDebug (for testing) will be in a separate PR