### PR TITLE
Fix Revert "Vehicle DB improvements (#44)"

### DIFF
--- a/code/client/src/core/dev_features.cpp
+++ b/code/client/src/core/dev_features.cpp
@@ -341,10 +341,10 @@ namespace MafiaMP::Core {
         }
 
         // TODO(Greavesy): May not be 'random' if our application does not use srand, but not important as only debug feature
-        const uint32_t randomIndex = rand() % vehiclesDB.Get()->GetVehiclesCount();
+        const uint32_t randomIndex = rand() % vehiclesDB->GetVehiclesCount();
 
         using namespace SDK::mafia::framework;
-        const C_VehiclesDatabase::TItemAccessorConst &selectedCar = vehiclesDB.Get()->GetVehicleByIndex(randomIndex);
+        const C_VehiclesDatabase::TItemAccessorConst &selectedCar = vehiclesDB->GetVehicleByIndex(randomIndex);
         if (const auto *vehicle = selectedCar.Get()) {
             const auto vehicleID = vehicle->GetID();
             if (vehicle->GetID() == 0) {

--- a/code/client/src/sdk/gamedb/tables/vehicles/s_vehicles_table_item.h
+++ b/code/client/src/sdk/gamedb/tables/vehicles/s_vehicles_table_item.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "sdk/mafia/tables/table_defines.h"
-#include "sdk/mafia/tables/vehicle/vehicle_defines.h"
-#include "sdk/mafia/traffic/traffic_defines.h"
+#include "../../../mafia/tables/table_defines.h"
+#include "../../../mafia/tables/vehicle/vehicle_defines.h"
+#include "../../../mafia/traffic/traffic_defines.h"
 
 #include <utils/bitops.h>
 

--- a/code/client/src/sdk/gamedb/tables/vehicles/s_vehicles_table_item.h
+++ b/code/client/src/sdk/gamedb/tables/vehicles/s_vehicles_table_item.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "sdk/mafia/tables/table_defines.h"
+#include "sdk/mafia/tables/vehicle/vehicle_defines.h"
+#include "sdk/mafia/traffic/traffic_defines.h"
+
+#include <utils/bitops.h>
+
+#include <stdint.h>
+
+namespace SDK {
+    namespace gamedb::tables::vehicles {
+        struct S_VehiclesTableItem {
+          public:
+
+            bool HasCommonFlags(const mafia::traffic::E_TrafficCommonFlags flags) const {
+                return BIT_HAS(m_CommonFlags, flags);
+            }
+
+            bool HasVehicleFlags(const mafia::traffic::E_TrafficVehicleFlags flags) const {
+                return BIT_HAS(m_VehicleFlags, flags);
+            }
+
+            bool HasVehicleLookFlags(const mafia::traffic::E_TrafficVehicleLookFlags flags) const {
+                return BIT_HAS(m_VehicleLookFlags, flags);
+            }
+
+            bool HasVehicleFunctionFlags(const mafia::tables::vehicle::E_VehiclesTableFunctionFlags flags) const {
+                return BIT_HAS(m_VehicleFunctionFlags, flags);
+            }
+
+            // Accessors for all properties within the table item;
+            // Note that there is no accessor for flags, use public API to query instead
+            uint32_t GetID() const {
+                return m_ID;
+            }
+
+            const char *GetModelName() const {
+                return &m_ModelName[0];
+            }
+
+            const char *GetSoundVehicleSwitch() const {
+                return &m_SoundVehicleSwitch[0];
+            }
+
+            mafia::tables::E_RadioStation GetRadioStation() const {
+                return m_RadioStation;
+            };
+
+            float GetRadioSoundQuality() const {
+                return m_RadioSoundQuality;
+            }
+
+            uint32_t GetTexID() const {
+                return m_TexID;
+            }
+
+            uint64_t GetTexHash() const {
+                return m_TexHash;
+            }
+
+            const char *GetBrandNameUI() const {
+                return &m_BrandNameUI[0];
+            }
+
+            const char *GetModelNameUI() const {
+                return &m_ModelNameUI[0];
+            }
+
+            const char *GetLogoNameUI() const {
+                return &m_LogoNameUI[0];
+            }
+
+            uint32_t GetStealCoefficient() const {
+                return m_StealCoefficient;
+            }
+
+            uint32_t GetPrice() const {
+                return m_Price;
+            }
+
+            float GetMinDirt() const {
+                return m_MinDirt;
+            }
+
+            float GetMaxDirt() const {
+                return m_MaxDirt;
+            }
+
+            float GetMinRust() const {
+                return m_MinDirt;
+            }
+
+            float GetMaxRust() const {
+                return m_MaxRust;
+            }
+
+            mafia::tables::vehicle::E_VehicleRaceClass GetRaceClass() const {
+                return m_RaceClass;
+            }
+
+            float GetTrunkDoorOffsetX() const {
+                return m_TrunkDockOffsetX;
+            }
+
+            float GetTrunkDoorOffsetY() const {
+                return m_TrunkDockOffsetY;
+            }
+
+          private:
+            uint32_t m_ID = 0;
+            mafia::traffic::E_TrafficCommonFlags m_CommonFlags;
+            mafia::traffic::E_TrafficVehicleFlags m_VehicleFlags;
+            mafia::traffic::E_TrafficVehicleLookFlags m_VehicleLookFlags;
+            mafia::tables::vehicle::E_VehiclesTableFunctionFlags m_VehicleFunctionFlags;
+            char m_ModelName[32];
+            char m_SoundVehicleSwitch[32];
+            mafia::tables::E_RadioStation m_RadioStation;
+            float m_RadioSoundQuality = 100.0f;
+            uint32_t m_TexID          = 0;
+            uint64_t m_TexHash        = 0;
+            char m_BrandNameUI[32];
+            char m_ModelNameUI[32];
+            char m_LogoNameUI[32];
+            uint32_t m_StealCoefficient = 0;
+            uint32_t m_Price            = 0;
+            float m_MinDirt             = 0.0f;
+            float m_MinRust             = 0.0f;
+            float m_MaxDirt             = 0.0f;
+            float m_MaxRust             = 0.0f;
+            mafia::tables::vehicle::E_VehicleRaceClass m_RaceClass;
+            float m_TrunkDockOffsetX = 0.0f;
+            float m_TrunkDockOffsetY = 0.0f;
+        };
+    } // namespace gamedb::tables::vehicles
+} // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_vehicles_database.cpp
+++ b/code/client/src/sdk/mafia/framework/c_vehicles_database.cpp
@@ -4,7 +4,6 @@
 
 namespace SDK {
     namespace mafia::framework {
-
         uint32_t C_VehiclesDatabase::GetVehiclesCount() {
             return hook::this_call<uint32_t>(gPatterns.C_VehiclesDatabase__GetVehiclesCount, this);
         }
@@ -14,7 +13,7 @@ namespace SDK {
             return hook::this_call<const TItemAccessorConst &>(gPatterns.C_VehiclesDatabase__GetVehicleByIndex, this, &TempA2, index);
         }
 
-       const C_VehiclesDatabase::TItemAccessorConst &C_VehiclesDatabase::GetVehicleByID(uint32_t index) {
+        const C_VehiclesDatabase::TItemAccessorConst &C_VehiclesDatabase::GetVehicleByID(uint32_t index) {
             TItemAccessorConst TempA2; // the game function outputs the result in a2 and return, so we can get away with just one
             return hook::this_call<const TItemAccessorConst &>(gPatterns.C_VehiclesDatabase__GetVehicleByID, this, &TempA2, index);
         }
@@ -23,6 +22,5 @@ namespace SDK {
             TItemAccessorConst TempA2; // the game function outputs the result in a2 and return, so we can get away with just one
             return hook::this_call<const TItemAccessorConst &>(gPatterns.C_VehiclesDatabase__GetVehicleByModel, this, &TempA2, hash);
         }
-
     } // namespace mafia::framework
 } // namespace SDK

--- a/code/client/src/sdk/mafia/framework/c_vehicles_database.h
+++ b/code/client/src/sdk/mafia/framework/c_vehicles_database.h
@@ -1,42 +1,10 @@
 #pragma once
 
-#include "sdk/mafia/tables/table_defines.h"
-#include "sdk/mafia/tables/vehicle/vehicle_defines.h"
-#include "sdk/mafia/traffic/traffic_defines.h"
-#include "sdk/ue/sys/sodb/c_database_interface.h"
-
-#include <stdint.h>
+#include "../../gamedb/tables/vehicles/s_vehicles_table_item.h"
+#include "../../ue/sys/sodb/c_database_interface.h"
 
 namespace SDK {
     namespace mafia::framework {
-
-        // NB: This should actually reside in the namespace: gamedb::tables::vehicles
-        struct S_VehiclesTableItem {
-            uint32_t m_ID                   = 0;
-            mafia::traffic::E_TrafficCommonFlags m_CommonFlags;
-            mafia::traffic::E_TrafficVehicleFlags m_VehicleFlags;
-            mafia::traffic::E_TrafficVehicleLookFlags m_VehicleLookFlags;
-            mafia::tables::vehicle::E_VehiclesTableFunctionFlags m_VehicleFunctionFlags;
-            char m_ModelName[32];
-            char m_SoundVehicleSwitch[32];
-            mafia::tables::E_RadioStation m_RadioStation;
-            float m_RadioSoundQuality       = 100.0f;
-            uint32_t m_TexID                = 0;
-            uint64_t m_TexHash              = 0;
-            char m_BrandNameUI[32];
-            char m_ModelNameUI[32];
-            char m_LogoNameUI[32];
-            uint32_t m_StealCoefficient     = 0;
-            uint32_t m_Price                = 0;
-            float m_MinDirt                 = 0.0f;
-            float m_MinRust                 = 0.0f;
-            float m_MaxDirt                 = 0.0f;
-            float m_MaxRust                 = 0.0f;
-            mafia::tables::vehicle::E_VehicleRaceClass m_RaceClass;
-            float m_TrunkDockOffsetX        = 0.0f;
-            float m_TrunkDockOffsetY        = 0.0f;
-        };
-
         /**
          * Contains XBin data at runtime; assume to be read-only
          */
@@ -44,8 +12,8 @@ namespace SDK {
           public:
             uint32_t GetVehiclesCount();
 
-              typedef ue::sys::sodb::C_Database::C_AccessorConst<S_VehiclesTableItem> TItemAccessorConst;
-              const TItemAccessorConst& GetVehicleByIndex(uint32_t index);
+            typedef ue::sys::sodb::C_Database::C_AccessorConst<SDK::gamedb::tables::vehicles::S_VehiclesTableItem> TItemAccessorConst;
+            const TItemAccessorConst &GetVehicleByIndex(uint32_t index);
 
             const TItemAccessorConst &GetVehicleByID(uint32_t index);
 

--- a/code/client/src/sdk/ue/c_weak_ptr.h
+++ b/code/client/src/sdk/ue/c_weak_ptr.h
@@ -7,6 +7,12 @@ namespace SDK {
         template <typename T>
         class C_WeakPtr {
           public:
+            uintptr_t unk;
+            T *m_Ptr = nullptr;
+            uintptr_t unk3;
+            uintptr_t unk4;
+            uint8_t paaddd[32];
+
             T *Get() const {
                 return m_Ptr;
             }
@@ -15,12 +21,9 @@ namespace SDK {
                 return m_Ptr != nullptr;
             }
 
-          public:
-            uintptr_t unk;
-            T *m_Ptr = nullptr;
-            uintptr_t unk3;
-            uintptr_t unk4;
-            uint8_t paaddd[32];
+            T *operator->() const {
+                return m_Ptr;
+            }
         };
     } // namespace ue
 } // namespace SDK

--- a/code/client/src/sdk/ue/c_weak_ptr.h
+++ b/code/client/src/sdk/ue/c_weak_ptr.h
@@ -7,11 +7,20 @@ namespace SDK {
         template <typename T>
         class C_WeakPtr {
           public:
+            T *Get() const {
+                return m_Ptr;
+            }
+
+            bool IsValid() const {
+                return m_Ptr != nullptr;
+            }
+
+          private:
             uintptr_t unk;
-            T* m_Ptr = nullptr;
+            T *m_Ptr = nullptr;
             uintptr_t unk3;
             uintptr_t unk4;
             uint8_t paaddd[32];
         };
-    }
+    } // namespace ue
 } // namespace SDK

--- a/code/client/src/sdk/ue/c_weak_ptr.h
+++ b/code/client/src/sdk/ue/c_weak_ptr.h
@@ -15,7 +15,7 @@ namespace SDK {
                 return m_Ptr != nullptr;
             }
 
-          private:
+          public:
             uintptr_t unk;
             T *m_Ptr = nullptr;
             uintptr_t unk3;

--- a/code/client/src/sdk/ue/sys/sodb/c_database_interface.h
+++ b/code/client/src/sdk/ue/sys/sodb/c_database_interface.h
@@ -4,12 +4,9 @@
 
 namespace SDK {
     namespace ue::sys::sodb {
-
         class C_Database {
           public:
-
             // Accessor for table items
-            // Todo(Greavesy): add a few operator overloads
             template <typename T>
             class C_AccessorConst {
               public:
@@ -28,7 +25,6 @@ namespace SDK {
 
         class C_DatabaseInterface {
           public:
-
             virtual ~C_DatabaseInterface()                               = 0;
             virtual void C_DatabaseEventListener_OnMountPointMounted()   = 0;
             virtual void C_DatabaseEventListener_OnMountPointUnmounted() = 0;
@@ -37,11 +33,9 @@ namespace SDK {
             virtual uint32_t GetID()                                     = 0;
 
           private:
-
-              // 0x20 is an instance of C_Database
-              // 0x28 appears to be something from the C_Database
-              // 0x30 is an instance of C_XBinMountPoint
-
+            // 0x20 is an instance of C_Database
+            // 0x28 appears to be something from the C_Database
+            // 0x30 is an instance of C_XBinMountPoint
         };
     }; // namespace ue::sys::sodb
 };     // namespace SDK

--- a/code/client/src/sdk/ue/sys/sodb/c_database_interface.h
+++ b/code/client/src/sdk/ue/sys/sodb/c_database_interface.h
@@ -18,6 +18,10 @@ namespace SDK {
                     return m_Item != nullptr;
                 }
 
+                T *operator->() const {
+                    return m_Item;
+                }
+
               private:
                 const T *m_Item = nullptr;
             };

--- a/code/client/src/sdk/ue/sys/sodb/c_database_system.cpp
+++ b/code/client/src/sdk/ue/sys/sodb/c_database_system.cpp
@@ -4,10 +4,8 @@
 
 namespace SDK {
     namespace ue::sys::sodb {
-        
         C_DatabaseInterface *C_DatabaseSystem::GetDatabase(const ue::sys::utils::C_HashName *databaseName) {
             return hook::this_call<C_DatabaseInterface *>(gPatterns.C_DatabaseSystem__GetDatabase, this, databaseName);
         }
-
     }; // namespace ue::sys::sodb
 };     // namespace SDK

--- a/code/client/src/sdk/ue/sys/sodb/c_database_system.h
+++ b/code/client/src/sdk/ue/sys/sodb/c_database_system.h
@@ -4,13 +4,11 @@
 
 namespace SDK {
     namespace ue::sys::sodb {
-
         class C_DatabaseInterface;
 
         class C_DatabaseSystem {
           public:
-
             C_DatabaseInterface *GetDatabase(const ue::sys::utils::C_HashName *databaseName);
         };
-    }; // namespace ue::sys::odb
+    }; // namespace ue::sys::sodb
 };     // namespace SDK

--- a/code/client/src/sdk/ue/sys/sodb/c_sys_odb.h
+++ b/code/client/src/sdk/ue/sys/sodb/c_sys_odb.h
@@ -4,12 +4,11 @@
 
 namespace SDK {
     namespace ue::sys::sodb {
-        class C_SysODB : public C_DatabaseSystem {
+        class C_SysODB: public C_DatabaseSystem {
           public:
-
             static C_SysODB *GetInstance() {
                 return *hook::call<C_SysODB **>(gPatterns.C_SysODB__GetInstance);
             }
         };
-    }; // namespace ue::sys::odb
-}; // namespace SDK
+    }; // namespace ue::sys::sodb
+};     // namespace SDK


### PR DESCRIPTION
We use C_WeakPtr here:

https://github.com/MafiaHub/MafiaMP/blob/d0d3017cae30dd854e1e50a7f0ed0ee3c560c899/code/client/src/game/streaming/entity_factory.cpp#L20

https://github.com/MafiaHub/MafiaMP/blob/d0d3017cae30dd854e1e50a7f0ed0ee3c560c899/code/client/src/game/streaming/entity_factory.cpp#L92

Probably the first one cause the crash. (when two players try to connect to the server)

---

The crash is fixed by changing the properties of C_WeakPtr back to public.

Probably, because the game uses C_WeakPtr under the hood.
