### PR TITLE
Move PlayerVehicleEnter/Leave events to Player

### DIFF
--- a/code/server/src/core/builtins/player.cpp
+++ b/code/server/src/core/builtins/player.cpp
@@ -2,9 +2,9 @@
 
 #include "vehicle.h"
 
-#include "shared/modules/human_sync.hpp"
 #include "shared/game_rpc/add_weapon.h"
 #include "shared/game_rpc/human/human_setprops.h"
+#include "shared/modules/human_sync.hpp"
 #include "shared/rpc/chat_message.h"
 
 namespace MafiaMP::Scripting {
@@ -87,6 +87,26 @@ namespace MafiaMP::Scripting {
         engine->InvokeEvent("playerDisconnected", playerObj);
     }
 
+    void Human::EventPlayerVehicleEnter(flecs::entity player, flecs::entity vehicle, int seatIndex) {
+        const auto engine = MafiaMP::Server::GetNodeEngine();
+        V8_RESOURCE_LOCK(engine);
+
+        auto vehicleObj = Vehicle::WrapVehicle(engine, vehicle);
+        auto playerObj  = WrapHuman(engine, player);
+
+        engine->InvokeEvent("playerVehicleEnter", playerObj, vehicleObj, seatIndex);
+    }
+
+    void Human::EventPlayerVehicleLeave(flecs::entity player, flecs::entity vehicle) {
+        const auto engine = MafiaMP::Server::GetNodeEngine();
+        V8_RESOURCE_LOCK(engine)
+
+        auto vehicleObj = Vehicle::WrapVehicle(engine, vehicle);
+        auto playerObj  = WrapHuman(engine, player);
+
+        engine->InvokeEvent("playerVehicleLeave", playerObj, vehicleObj);
+    }
+
     void Human::Register(v8::Isolate *isolate, v8pp::module *rootModule) {
         if (!rootModule) {
             return;
@@ -104,4 +124,4 @@ namespace MafiaMP::Scripting {
         cls.function("sendChatToAll", &Human::SendChatToAll);
         rootModule->class_("Human", cls);
     }
-}
+} // namespace MafiaMP::Scripting

--- a/code/server/src/core/builtins/player.h
+++ b/code/server/src/core/builtins/player.h
@@ -11,6 +11,8 @@ namespace MafiaMP::Scripting {
         static void EventPlayerDied(flecs::entity e);
         static void EventPlayerConnected(flecs::entity e);
         static void EventPlayerDisconnected(flecs::entity e);
+        static void EventPlayerVehicleEnter(flecs::entity player, flecs::entity vehicle, int seatIndex);
+        static void EventPlayerVehicleLeave(flecs::entity player, flecs::entity vehicle);
 
         static void Register(v8::Isolate *isolate, v8pp::module *rootModule);
 

--- a/code/server/src/core/builtins/vehicle.cpp
+++ b/code/server/src/core/builtins/vehicle.cpp
@@ -6,24 +6,8 @@
 #include "shared/modules/vehicle_sync.hpp"
 
 namespace MafiaMP::Scripting {
-    void Vehicle::EventVehiclePlayerEnter(flecs::entity vehicle, flecs::entity player, int seatIndex) {
-        const auto engine = MafiaMP::Server::GetNodeEngine();
-        V8_RESOURCE_LOCK(engine);
-
-        auto vehicleObj = v8pp::class_<Vehicle>::create_object(engine->GetIsolate(), vehicle.id());
-        auto playerObj  = Human::WrapHuman(engine, player);
-
-        engine->InvokeEvent("vehiclePlayerEnter", vehicleObj, playerObj, seatIndex);
-    }
-
-    void Vehicle::EventVehiclePlayerLeave(flecs::entity vehicle, flecs::entity player) {
-        const auto engine = MafiaMP::Server::GetNodeEngine();
-        V8_RESOURCE_LOCK(engine)
-
-        auto vehicleObj = v8pp::class_<Vehicle>::create_object(engine->GetIsolate(), vehicle.id());
-        auto playerObj  = Human::WrapHuman(engine, player);
-
-        engine->InvokeEvent("vehiclePlayerLeave", vehicleObj, playerObj);
+    v8::Local<v8::Object> Vehicle::WrapVehicle(Framework::Scripting::Engines::Node::Engine *engine, flecs::entity e) {
+        return v8pp::class_<Scripting::Vehicle>::create_object(engine->GetIsolate(), e.id());
     }
 
     std::string Vehicle::ToString() const {

--- a/code/server/src/core/builtins/vehicle.cpp
+++ b/code/server/src/core/builtins/vehicle.cpp
@@ -1,5 +1,4 @@
 #include "vehicle.h"
-#include "player.h"
 
 #include "scripting/engines/node/engine.h"
 #include "shared/game_rpc/vehicle/vehicle_setprops.h"

--- a/code/server/src/core/builtins/vehicle.h
+++ b/code/server/src/core/builtins/vehicle.h
@@ -13,10 +13,9 @@ namespace MafiaMP::Scripting {
       public:
         Vehicle(flecs::entity_t ent): Entity(ent) {}
 
-        static void EventVehiclePlayerEnter(flecs::entity vehicle, flecs::entity player, int seatIndex);
-        static void EventVehiclePlayerLeave(flecs::entity vehicle, flecs::entity player);
-
         static void Register(v8::Isolate *isolate, v8pp::module *rootModule);
+
+        static v8::Local<v8::Object> WrapVehicle(Framework::Scripting::Engines::Node::Engine *engine, flecs::entity e);
 
         std::string ToString() const override;
 
@@ -64,7 +63,5 @@ namespace MafiaMP::Scripting {
 
         v8::Local<v8::Object> GetWindowTint();
         void SetWindowTint(Framework::Scripting::Engines::Node::Builtins::ColorRGBA tint);
-
-
     };
 } // namespace MafiaMP::Scripting

--- a/code/server/src/core/modules/vehicle.cpp
+++ b/code/server/src/core/modules/vehicle.cpp
@@ -14,7 +14,7 @@
 #include "shared/messages/vehicle/vehicle_update.h"
 #include "shared/modules/vehicle_sync.hpp"
 
-#include "core/builtins/vehicle.h"
+#include "core/builtins/player.h"
 
 #include <utils/safe_string.h>
 
@@ -143,7 +143,7 @@ namespace MafiaMP::Core::Modules {
     }
 
     void Vehicle::InitRPCs(std::shared_ptr<Framework::World::ServerEngine> srv, Framework::Networking::NetworkServer *net) {
-        net->RegisterGameRPC<Shared::RPC::VehiclePlayerEnter>([srv](SLNet::RakNetGUID guid, Shared::RPC::VehiclePlayerEnter* msg) {
+        net->RegisterGameRPC<Shared::RPC::VehiclePlayerEnter>([srv](SLNet::RakNetGUID guid, Shared::RPC::VehiclePlayerEnter *msg) {
             const auto playerEntity = srv->GetEntityByGUID(guid.g);
             if (!playerEntity.is_alive()) {
                 return;
@@ -154,7 +154,7 @@ namespace MafiaMP::Core::Modules {
                 return;
             }
 
-            Scripting::Vehicle::EventVehiclePlayerEnter(vehicleEntity, playerEntity, msg->seatIndex);
+            Scripting::Human::EventPlayerVehicleEnter(playerEntity, vehicleEntity, msg->seatIndex);
         });
 
         net->RegisterGameRPC<Shared::RPC::VehiclePlayerLeave>([srv](SLNet::RakNetGUID guid, Shared::RPC::VehiclePlayerLeave *msg) {
@@ -168,7 +168,7 @@ namespace MafiaMP::Core::Modules {
                 return;
             }
 
-            Scripting::Vehicle::EventVehiclePlayerLeave(vehicleEntity, playerEntity);
+            Scripting::Human::EventPlayerVehicleLeave(playerEntity, vehicleEntity);
         });
     }
 } // namespace MafiaMP::Core::Modules

--- a/gamemode/index.js
+++ b/gamemode/index.js
@@ -306,12 +306,12 @@ sdk.on("gamemodeUnloading", () => {
     console.log("[GAMEMODE] Gamemode unloading!");
 });
 
-sdk.on("vehiclePlayerEnter", (vehicle, player, seatIndex) => {
+sdk.on("playerVehicleEnter", (player, vehicle, seatIndex) => {
     console.log(`[GAMEMODE] Player ${player.nickname} entered vehicle ${vehicle.name} = ${seatIndex}!`);
     vehicle.setEngineOn(true);
 });
 
-sdk.on("vehiclePlayerLeave", (vehicle, player) => {
+sdk.on("playerVehicleLeave", (player, vehicle) => {
     console.log(`[GAMEMODE] Player ${player.nickname} exited vehicle ${vehicle.name}!`);
     vehicle.setEngineOn(false);
 });
@@ -578,9 +578,7 @@ RegisterChatCommand("colors", (player, message, command, args) => {
     player.sendChat(`[SERVER] Primary color changed to rgb: ${colorPrimary.r}, ${colorPrimary.g}, ${colorPrimary.b}`);
 
     const colorSecondary = veh.getColorSecondary();
-    player.sendChat(
-        `[SERVER] Secondary color changed to rgb: ${colorSecondary.r}, ${colorSecondary.g}, ${colorSecondary.b}`
-    );
+    player.sendChat(`[SERVER] Secondary color changed to rgb: ${colorSecondary.r}, ${colorSecondary.g}, ${colorSecondary.b}`);
 });
 
 RegisterChatCommand("wheelcol", (player, message, command, args) => {
@@ -618,15 +616,12 @@ RegisterChatCommand("wintint", (player, message, command, args) => {
     veh.setWindowTint(sdk.RGBA(getRandomColor(), getRandomColor(), getRandomColor(), getRandomColor()));
 
     const windowTint = veh.getWindowTint();
-    player.sendChat(
-        `[SERVER] Window tint changed to rgba: ${windowTint.r}, ${windowTint.g}, ${windowTint.b}, ${windowTint.a}`
-    );
+    player.sendChat(`[SERVER] Window tint changed to rgba: ${windowTint.r}, ${windowTint.g}, ${windowTint.b}, ${windowTint.a}`);
 });
 
 RegisterChatCommand("wep", (player, message, command, args) => {
-    // TODO: doesn't works yet
-
-    const weaponId = parseInt(args[0], 10) ?? 85;
+    const wantedWeaponId = parseInt(args[0], 10);
+    const weaponId = Number.isInteger(wantedWeaponId) ? wantedWeaponId : 85;
     player.addWeapon(weaponId, 200);
     player.sendChat(`[SERVER] Weapon (id: ${weaponId}) received!`);
 });


### PR DESCRIPTION
Makes more sense to attach the events to the Player: he is the one who causes the events.
- Who: the player
- Where: In the vehicle
- What: enter / leave


To be more precise we should attach it to `Human` and transfer it to `Player` but we don't yet have this level of layers.

---

This is also the case in other implementations (who created a usage).

Some examples:
- Game LUA natives: `enums.HumanMessages.ENTER_VEHICLE`, `enums.HumanMessages.LEAVE_VEHICLE`
- M2MP: [onPlayerVehicleEnter](https://github.com/mafia2online/Mafia2-Online/blob/6e941527fa63195430d0149f8f680f3f5da3631f/Server/CNetworkVehicle.cpp#L818), [onPlayerVehicleExit](https://github.com/mafia2online/Mafia2-Online/blob/6e941527fa63195430d0149f8f680f3f5da3631f/Server/CNetworkVehicle.cpp#L848)
- Alt:V:  [PlayerEnterVehicle](https://docs.altv.mp/cs/articles/events/player-events/player-enter-vehicle.html), [PlayerLeaveVehicle](https://docs.altv.mp/cs/articles/events/player-events/player-leave-vehicle.html)
