### PR TITLE
Reset chat history position

### DIFF
--- a/code/client/src/core/ui/chat.cpp
+++ b/code/client/src/core/ui/chat.cpp
@@ -93,7 +93,8 @@ namespace MafiaMP::Core::UI {
                     strcpy(_inputText, "");
                 }
 
-                _isFocused = false;
+                _historyPos = -1;
+                _isFocused  = false;
                 LockControls(false);
 
                 if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) {


### PR DESCRIPTION
When a user enters multiple messages in chat, they are added to a history.
The user has the possibility to reopen the chat and browse the messages he has sent.

Suppose the user goes back two places in their history and then closes the chat or sends a message (which closes the chat).
If the user reopens their chat, they will resume browsing their history at position -2 instead of starting from the last message sent.

This PR will fix the issue.