### PR TITLE
Fix: Add VehicleSync::UpdateData to vehicle entity

### DIFF
--- a/code/server/src/core/modules/vehicle.cpp
+++ b/code/server/src/core/modules/vehicle.cpp
@@ -48,6 +48,7 @@ namespace MafiaMP::Core::Modules {
         auto &frame     = e.ensure<Framework::World::Modules::Base::Frame>();
         frame.modelName = "berkley_810"; /* TODO */
 
+        e.add<Shared::Modules::VehicleSync::UpdateData>();
         e.add<CarData>();
         e.add<Framework::World::Modules::Base::RemovedOnGameModeReload>();
 


### PR DESCRIPTION
I accidentally removed the addition of `VehicleSync::UpdateData` on the vehicle entity

https://github.com/MafiaHub/MafiaMP/commit/a2e42f7ccc960aac190f3098c87714c7852a789e#diff-9da33544966d1e2c2602e3066a4cd1a10ea0c7f81bb799e45ba69ca74638d94dL51

As explained by @zpl-zak we need it:

> ensure() call does both add the component and retrieve a reference
> otherwise the entity has incomplete data and can not be considered a valid Vehicle
> we will eventually start using ecs prefabs, so it becomes more obvious what components the entities consist of, but for now we just attach components as we go