### PR TITLE
fix: ensure cars start with brakes pressed

### DIFF
--- a/code/client/src/core/modules/vehicle.cpp
+++ b/code/client/src/core/modules/vehicle.cpp
@@ -129,6 +129,7 @@ namespace MafiaMP::Core::Modules {
                 transform.SetRot(newRot);
                 transform.SetPos(newPos);
                 car->GetVehicle()->SetVehicleMatrix(transform, SDK::ue::sys::core::E_TransformChangeType::DEFAULT);
+                car->GetVehicle()->SetBrake(1.0f, true);
 
                 auto trackingData = ent.get_mut<Core::Modules::Vehicle::Tracking>();
                 trackingData->car = car;

--- a/code/shared/modules/vehicle_sync.hpp
+++ b/code/shared/modules/vehicle_sync.hpp
@@ -17,7 +17,7 @@ namespace MafiaMP::Shared::Modules {
         struct UpdateData {
             glm::vec3 angularVelocity {};
             bool beaconLightsOn = false;
-            float brake         = 0.0f;
+            float brake         = 1.0f;
             glm::vec4 colorPrimary {1.0f, 1.0f, 1.0f, 1.0f};
             glm::vec4 colorSecondary {1.0f, 1.0f, 1.0f, 1.0f};
             float dirt                                                     = 0.0f;


### PR DESCRIPTION
Fixes a bug where idle vehicles would occasionally slide down the road as players approach them.

This happened because we did not apply initial brake value for the newly spawned vehicles to use.