### PR TITLE
Logging: cast enums to int for fmt 12 format calls

### DIFF
--- a/code/client/src/core/hooks/hud.cpp
+++ b/code/client/src/core/hooks/hud.cpp
@@ -12,7 +12,7 @@ typedef int64_t(__fastcall *C_MenuBase__OnScriptedMenuEvent_t)(void *pThis, int,
 C_MenuBase__OnScriptedMenuEvent_t C_MenuBase__OnScriptedMenuEvent_original = nullptr;
 int64_t C_MenuBase__OnScriptedMenuEvent(void *pThis, int unk, SDK::mafia::ui::menu::C_MenuBase::E_ScriptedMenuEvent menuEvent) {
     // TODO: broadcast over network
-    Framework::Logging::GetLogger("Hooks")->debug("C_MenuBase::OnScriptedMenuEvent: unk {} event {}", unk, menuEvent);
+    Framework::Logging::GetLogger("Hooks")->debug("C_MenuBase::OnScriptedMenuEvent: unk {} event {}", unk, static_cast<int>(menuEvent));
     return C_MenuBase__OnScriptedMenuEvent_original(pThis, unk, menuEvent);
 }
 

--- a/code/client/src/core/hooks/hud.cpp
+++ b/code/client/src/core/hooks/hud.cpp
@@ -12,7 +12,7 @@ typedef int64_t(__fastcall *C_MenuBase__OnScriptedMenuEvent_t)(void *pThis, int,
 C_MenuBase__OnScriptedMenuEvent_t C_MenuBase__OnScriptedMenuEvent_original = nullptr;
 int64_t C_MenuBase__OnScriptedMenuEvent(void *pThis, int unk, SDK::mafia::ui::menu::C_MenuBase::E_ScriptedMenuEvent menuEvent) {
     // TODO: broadcast over network
-    Framework::Logging::GetLogger("Hooks")->debug("C_MenuBase::OnScriptedMenuEvent: unk {} event {}", unk, static_cast<int>(menuEvent));
+    Framework::Logging::GetLogger("Hooks")->debug("C_MenuBase::OnScriptedMenuEvent: unk {} event {}", unk, fmt::underlying(menuEvent));
     return C_MenuBase__OnScriptedMenuEvent_original(pThis, unk, menuEvent);
 }
 

--- a/code/client/src/core/hooks/navigation.cpp
+++ b/code/client/src/core/hooks/navigation.cpp
@@ -19,7 +19,7 @@ C_Navigation__OnDistrictChange_t C_Navigation__OnDistrictChange_original = nullp
 int64_t C_Navigation__OnDistrictChange(void *pThis, SDK::mafia::framework::director::I_GameDirector::C_DistrictDefinition const &def) {
     if (MafiaMP::Core::gApplication && MafiaMP::Core::gApplication->IsInitialized()) {
         const auto newDistrictID = static_cast<MafiaMP::Game::Helpers::Districts>(def.districtID);
-        Framework::Logging::GetLogger("Hooks")->trace("C_Navigation::OnDistrictChange: New district is {}", newDistrictID);
+        Framework::Logging::GetLogger("Hooks")->trace("C_Navigation::OnDistrictChange: New district is {}", static_cast<int>(newDistrictID));
         MafiaMP::Core::gApplication->SetLastDistrictID(newDistrictID);
     }
     return C_Navigation__OnDistrictChange_original(pThis, def);

--- a/code/client/src/core/hooks/navigation.cpp
+++ b/code/client/src/core/hooks/navigation.cpp
@@ -19,7 +19,7 @@ C_Navigation__OnDistrictChange_t C_Navigation__OnDistrictChange_original = nullp
 int64_t C_Navigation__OnDistrictChange(void *pThis, SDK::mafia::framework::director::I_GameDirector::C_DistrictDefinition const &def) {
     if (MafiaMP::Core::gApplication && MafiaMP::Core::gApplication->IsInitialized()) {
         const auto newDistrictID = static_cast<MafiaMP::Game::Helpers::Districts>(def.districtID);
-        Framework::Logging::GetLogger("Hooks")->trace("C_Navigation::OnDistrictChange: New district is {}", static_cast<int>(newDistrictID));
+        Framework::Logging::GetLogger("Hooks")->trace("C_Navigation::OnDistrictChange: New district is {}", fmt::underlying(newDistrictID));
         MafiaMP::Core::gApplication->SetLastDistrictID(newDistrictID);
     }
     return C_Navigation__OnDistrictChange_original(pThis, def);

--- a/code/client/src/core/ui/devs/entity_browser.cpp
+++ b/code/client/src/core/ui/devs/entity_browser.cpp
@@ -225,7 +225,7 @@ namespace MafiaMP::Core::UI::Devs {
                             continue;
                     }
 
-                    auto sceneObjectName = fmt::format("{} {} {} ({})", i, sceneName, _filterIter->second, entity->GetType());
+                    auto sceneObjectName = fmt::format("{} {} {} ({})", i, sceneName, _filterIter->second, static_cast<int>(entity->GetType()));
                     if (ImGui::Selectable(sceneObjectName.c_str(), _selectedIndex == i)) {
                         _selectedIndex = i;
                     }

--- a/code/client/src/core/ui/devs/entity_browser.cpp
+++ b/code/client/src/core/ui/devs/entity_browser.cpp
@@ -225,7 +225,7 @@ namespace MafiaMP::Core::UI::Devs {
                             continue;
                     }
 
-                    auto sceneObjectName = fmt::format("{} {} {} ({})", i, sceneName, _filterIter->second, static_cast<int>(entity->GetType()));
+                    auto sceneObjectName = fmt::format("{} {} {} ({})", i, sceneName, _filterIter->second, fmt::underlying(entity->GetType()));
                     if (ImGui::Selectable(sceneObjectName.c_str(), _selectedIndex == i)) {
                         _selectedIndex = i;
                     }


### PR DESCRIPTION
fmt 12 (from the Framework spdlog/fmt vendored upgrade) no longer implicitly formats enums. Cast the menu event, district id, and entity type args in the client log/format calls to int, matching prior fmt 8 behavior.